### PR TITLE
fix(template): add src to setuptools and pytest pythonpath

### DIFF
--- a/templates/consumer-repo/pyproject.toml
+++ b/templates/consumer-repo/pyproject.toml
@@ -12,8 +12,11 @@ requires-python = ">=3.11"
 app = []
 dev = []
 
-[tool.setuptools]
-packages = []
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.setuptools.package-dir]
+"" = "src"
 
 [tool.black]
 line-length = 100
@@ -48,6 +51,7 @@ known-third-party = ["scripts", "tools"]
 
 [tool.pytest.ini_options]
 minversion = "7.0"
+pythonpath = ["src"]
 testpaths = ["tests"]
 python_files = ["test_*.py", "*_test.py"]
 addopts = ["-ra", "--strict-markers", "--strict-config"]


### PR DESCRIPTION
Consumer repos use src/ layout (e.g. src/example/). Without src in the package-dir and pytest pythonpath, tests that do 'from example import add' fail with ModuleNotFoundError.

https://claude.ai/code/session_01FC8XoyssN5v6hQCTtcjoB5