### PR TITLE
fix(claude-runner): add GITHUB_TOKEN to auth token step env

### DIFF
--- a/.github/workflows/reusable-claude-run.yml
+++ b/.github/workflows/reusable-claude-run.yml
@@ -210,6 +210,7 @@ jobs:
         id: auth_token
         env:
           APP_TOKEN: ${{ steps.app_token.outputs.token || '' }}
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           checkout_token="${APP_TOKEN:-${GITHUB_TOKEN}}"


### PR DESCRIPTION
The Select auth token step references GITHUB_TOKEN in shell but only has APP_TOKEN in its env block. With set -u, this causes "unbound variable" and skips all subsequent steps (checkout, API client setup, prompt assembly, Claude run).

https://claude.ai/code/session_01FC8XoyssN5v6hQCTtcjoB5