### PR TITLE
fix: update all cross-repo references from stranske/Workflows to iamk…

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 blank_issues_enabled: true
 contact_links:
   - name: 📚 Issue Format Guide
-    url: https://github.com/stranske/Workflows/blob/main/docs/ci/ISSUE_FORMAT_GUIDE.md
+    url: https://github.com/iamkayleb/Workflows/blob/main/docs/ci/ISSUE_FORMAT_GUIDE.md
     about: Learn the required format for agent issues and ChatGPT topic files
   - name: 📖 Agent Workflow Documentation
-    url: https://github.com/stranske/Workflows/blob/main/docs/ci/WORKFLOW_SYSTEM.md
+    url: https://github.com/iamkayleb/Workflows/blob/main/docs/ci/WORKFLOW_SYSTEM.md
     about: Understanding the agent workflow system and automation pipeline

--- a/.github/sync-manifest.yml
+++ b/.github/sync-manifest.yml
@@ -28,7 +28,7 @@ workflows:
   # Core CI/CD
   - source: .github/workflows/pr-00-gate.yml
     description: "Gate workflow - runs tests, lint, type checking before merge"
-    sync_mode: sync  # Temporarily forced to sync to push guard fixes to consumers
+    sync_mode: create_only  # Standard gate - consumers keep aligned unless explicitly diverging
 
   - source: .github/workflows/ci.yml
     description: "CI workflow - main continuous integration entry point"

--- a/.github/workflows/agents-autofix-loop.yml
+++ b/.github/workflows/agents-autofix-loop.yml
@@ -616,7 +616,7 @@ jobs:
       needs.prepare.outputs.should_run == 'true' &&
       needs.prepare.outputs.agent_type == 'codex'
     name: Run Codex autofix
-    uses: stranske/Workflows/.github/workflows/reusable-codex-run.yml@main
+    uses: iamkayleb/Workflows/.github/workflows/reusable-codex-run.yml@main
     with:
       prompt_file: .github/codex/prompts/autofix_from_ci_failure.md
       mode: autofix
@@ -640,7 +640,7 @@ jobs:
       needs.prepare.outputs.should_run == 'true' &&
       needs.prepare.outputs.agent_type == 'claude'
     name: Run Claude autofix
-    uses: stranske/Workflows/.github/workflows/reusable-claude-run.yml@main
+    uses: iamkayleb/Workflows/.github/workflows/reusable-claude-run.yml@main
     with:
       prompt_file: .github/codex/prompts/autofix_from_ci_failure.md
       mode: autofix

--- a/.github/workflows/agents-bot-comment-handler.yml
+++ b/.github/workflows/agents-bot-comment-handler.yml
@@ -225,7 +225,7 @@ jobs:
     name: Handle bot comments
     needs: resolve
     if: needs.resolve.outputs.should_run == 'true'
-    uses: stranske/Workflows/.github/workflows/reusable-bot-comment-handler.yml@main
+    uses: iamkayleb/Workflows/.github/workflows/reusable-bot-comment-handler.yml@main
     with:
       pr_number: ${{ needs.resolve.outputs.pr_number }}
       dry_run: ${{ inputs.dry_run == true }}

--- a/.github/workflows/agents-guard.yml
+++ b/.github/workflows/agents-guard.yml
@@ -71,7 +71,7 @@ jobs:
         if: >-
           github.event_name == 'pull_request_target' &&
           steps.api_client_base.outputs.available != 'true'
-        uses: "stranske/Workflows/.github/actions/setup-api-client@v1"
+        uses: "iamkayleb/Workflows/.github/actions/setup-api-client@main"
         with:
           secrets: ${{ toJSON(secrets) }}
           github_token: ${{ github.token }}
@@ -128,7 +128,7 @@ jobs:
 
       - name: Setup API client (Workflows fallback)
         if: github.event_name == 'pull_request' && steps.api_client_head.outputs.available != 'true'
-        uses: "stranske/Workflows/.github/actions/setup-api-client@v1"
+        uses: "iamkayleb/Workflows/.github/actions/setup-api-client@main"
         with:
           secrets: ${{ toJSON(secrets) }}
           github_token: ${{ github.token }}

--- a/.github/workflows/agents-keepalive-loop.yml
+++ b/.github/workflows/agents-keepalive-loop.yml
@@ -539,7 +539,7 @@ jobs:
       (needs.evaluate.outputs.action == 'run' ||
        needs.evaluate.outputs.action == 'fix' ||
        needs.evaluate.outputs.action == 'conflict')
-    uses: stranske/Workflows/.github/workflows/reusable-codex-run.yml@main
+    uses: iamkayleb/Workflows/.github/workflows/reusable-codex-run.yml@main
     secrets: inherit
     with:
       skip: >-

--- a/.github/workflows/agents-verifier.yml
+++ b/.github/workflows/agents-verifier.yml
@@ -209,7 +209,7 @@ jobs:
   verifier:
     needs: check
     if: needs.check.outputs.should_run == 'true'
-    uses: stranske/Workflows/.github/workflows/reusable-agents-verifier.yml@main
+    uses: iamkayleb/Workflows/.github/workflows/reusable-agents-verifier.yml@main
     with:
       # CI workflows to wait for before running verifier (Gate + PR 11 + selftest CI)
       ci_workflows: '["pr-00-gate.yml", "pr-11-ci-smoke.yml", "selftest-ci.yml"]'

--- a/docs/guides/CONSUMER_GATE_TROUBLESHOOTING.md
+++ b/docs/guides/CONSUMER_GATE_TROUBLESHOOTING.md
@@ -1001,3 +1001,100 @@ try {
 24. **PR assignees must be repo collaborators.** GitHub silently drops assignees that aren't collaborators. The bridge code wraps the `addAssignees` call in try/catch, so you won't see a hard failure — just an empty assignee list. Check repo collaborator settings if assignees are missing.
 
 25. **Use `automation_logins` from the agent registry.** The consumer's `.github/agents/registry.yml` is the right place to define which accounts handle each agent's work. The bridge reads this registry to determine assignees, so keep it in sync with your repo's actual bot collaborators.
+
+---
+
+## Part 5: Claude Runner Failures
+
+> Errors encountered getting the Claude agent runner (`reusable-claude-run.yml`) to
+> execute successfully when dispatched from consumer repos via keepalive or autofix.
+
+---
+
+### Error 29: `GITHUB_TOKEN: unbound variable` in "Select auth token" step
+
+**Job:** `run-claude` (via `agents-keepalive-loop.yml` or `agents-autofix-loop.yml`)
+**Exit code:** 1 (shell `set -u` violation)
+
+#### Root Cause
+
+The "Select auth token" step in `reusable-claude-run.yml` used `set -euo pipefail`, which includes `-u` (treat unset variables as errors). The shell script referenced `${GITHUB_TOKEN}` as a fallback:
+
+```bash
+checkout_token="${APP_TOKEN:-${GITHUB_TOKEN}}"
+```
+
+But `GITHUB_TOKEN` was not in the step's `env:` block — only `APP_TOKEN` was declared. When the GitHub App token minting step failed (no `WORKFLOWS_APP_ID` secret), `APP_TOKEN` was empty, so bash tried to expand `${GITHUB_TOKEN}`, which was unbound, and the step crashed.
+
+#### Cascade Effect
+
+This is the **real** root cause of the "Prompt preparation failed (missing prompt file)" error. When "Select auth token" fails:
+1. Checkout step skips (depends on auth token output)
+2. `setup-api-client` skips (no checkout)
+3. Prompt assembly skips (no files available)
+4. The "Run Claude" step sees an empty `PROMPT_FILE` variable and reports "missing prompt file"
+
+The misleading error diverts attention from the actual auth token issue.
+
+#### Fix
+
+Added `GITHUB_TOKEN: ${{ github.token }}` to the step's `env:` block:
+
+```yaml
+- name: Select auth token
+  id: auth_token
+  env:
+    APP_TOKEN: ${{ steps.app_token.outputs.token || '' }}
+    GITHUB_TOKEN: ${{ github.token }}
+  run: |
+    set -euo pipefail
+    checkout_token="${APP_TOKEN:-${GITHUB_TOKEN}}"
+```
+
+**Commit:** `a5c279d`
+
+---
+
+### Error 30: Fix on `main` not picked up — wrong repo reference
+
+**Job:** `autofix-claude` (via `agents-autofix-loop.yml`)
+**Symptom:** Same `GITHUB_TOKEN: unbound variable` error after fix was merged to `main`
+
+#### Root Cause
+
+The fix was merged to `iamkayleb/Workflows@main`, but the consumer's `agents-autofix-loop.yml` still referenced `stranske/Workflows/.github/workflows/reusable-claude-run.yml@main` — the **upstream** repo without the fix. The keepalive loop had been updated to `iamkayleb/Workflows` but the autofix loop had not.
+
+#### Fix
+
+Updated **all** `uses:` declarations across both in-repo workflows (`.github/workflows/`) and consumer templates (`templates/consumer-repo/`) to reference `iamkayleb/Workflows` instead of `stranske/Workflows`. This ensures the fork's own fixes are always used.
+
+**Affected files:** `agents-autofix-loop.yml`, `agents-keepalive-loop.yml`, `agents-bot-comment-handler.yml`, `agents-verifier.yml`, `agents-guard.yml`, `agents-80-pr-event-hub.yml`, `agents-81-gate-followups.yml`, `agents-issue-intake.yml`, `agents-orchestrator.yml`, `agents-pr-meta.yml`, `agents-pr-health.yml`, `autofix.yml`, `ci.yml`, `pr-00-gate.yml`.
+
+---
+
+### Error 31: Workflows scripts checkout referencing wrong repo
+
+**Job:** `run-claude` (Checkout Workflows scripts step)
+**Symptom:** Checkout fails or pulls wrong scripts
+
+#### Root Cause
+
+Line 264 of `reusable-claude-run.yml` had `repository: stranske/Workflows` for the scripts checkout. In a fork, this pulls scripts from the upstream instead of the fork.
+
+#### Fix
+
+Changed `repository: stranske/Workflows` to `repository: iamkayleb/Workflows`.
+
+**Commit:** `6a91a9c`
+
+---
+
+### Claude Runner Lessons
+
+26. **`set -euo pipefail` with `-u` requires all referenced variables in `env:`.** If a shell script references `${VAR}`, that variable must be in the step's `env:` block or it will cause an unbound variable error. `github.token` is only available via expressions — it's not automatically set as an environment variable.
+
+27. **Cascade failures obscure root causes.** When an early step fails in a reusable workflow, all dependent steps skip. The error message from the last step (which runs unconditionally or with a fallback) may be completely misleading. Always check the **first** failing step.
+
+28. **Fork repos must update cross-repo `uses:` references.** When forking a Workflows repository, all `uses: original-owner/Repo/...@ref` declarations in both the in-repo workflows AND consumer templates must be updated to point at the fork. Otherwise, changes to reusable workflows in the fork won't take effect.
+
+29. **Autofix and keepalive are separate dispatch chains.** Even if the keepalive loop is correctly configured, the autofix loop may have different `uses:` references. Both must be checked when verifying cross-repo workflow references.

--- a/templates/consumer-repo/.github/ISSUE_TEMPLATE/config.yml
+++ b/templates/consumer-repo/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: true
 contact_links:
   - name: 📖 Agent Workflow Guide
-    url: https://github.com/stranske/Workflows/blob/main/docs/ci/WORKFLOW_SYSTEM.md
+    url: https://github.com/iamkayleb/Workflows/blob/main/docs/ci/WORKFLOW_SYSTEM.md
     about: Learn how the agent automation system works

--- a/templates/consumer-repo/.github/workflows/agents-71-codex-belt-dispatcher.yml
+++ b/templates/consumer-repo/.github/workflows/agents-71-codex-belt-dispatcher.yml
@@ -200,7 +200,7 @@ jobs:
       - name: Checkout (for retry helpers)
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          repository: stranske/Workflows
+          repository: iamkayleb/Workflows
           ref: ${{ steps.workflows_ref.outputs.ref }}
           sparse-checkout: |
             .github/actions/setup-api-client

--- a/templates/consumer-repo/.github/workflows/agents-72-codex-belt-worker.yml
+++ b/templates/consumer-repo/.github/workflows/agents-72-codex-belt-worker.yml
@@ -323,7 +323,7 @@ jobs:
       - name: Checkout Workflows scripts
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          repository: stranske/Workflows
+          repository: iamkayleb/Workflows
           ref: ${{ steps.workflows_ref.outputs.ref }}
           sparse-checkout: |
             .github/actions/setup-api-client
@@ -594,7 +594,7 @@ jobs:
         if: ${{ steps.parallel.outputs.allowed == 'true' && (inputs.keepalive != true || steps.keepalive_gate.outputs.action != 'skip') }}
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          repository: stranske/Workflows
+          repository: iamkayleb/Workflows
           ref: ${{ steps.workflows_ref.outputs.ref }}
           token: ${{ env.GH_BELT_TOKEN }}
           fetch-depth: 1

--- a/templates/consumer-repo/.github/workflows/agents-80-pr-event-hub.yml
+++ b/templates/consumer-repo/.github/workflows/agents-80-pr-event-hub.yml
@@ -162,7 +162,7 @@ jobs:
       needs.resolve.outputs.pr_number != '' &&
       (needs.resolve.outputs.run_pr_meta == 'true' ||
        needs.resolve.outputs.run_bot_comments == 'true')
-    uses: stranske/Workflows/.github/workflows/reusable-pr-context.yml@main
+    uses: iamkayleb/Workflows/.github/workflows/reusable-pr-context.yml@main
     with:
       pr_number: ${{ fromJSON(needs.resolve.outputs.pr_number) }}
     secrets: inherit
@@ -173,7 +173,7 @@ jobs:
     if: |
       needs.resolve.outputs.pr_number != '' &&
       needs.resolve.outputs.run_pr_meta == 'true'
-    uses: stranske/Workflows/.github/workflows/reusable-20-pr-meta.yml@main
+    uses: iamkayleb/Workflows/.github/workflows/reusable-20-pr-meta.yml@main
     with:
       pr_number: ${{ fromJSON(needs.resolve.outputs.pr_number) }}
       comment_id: ${{ needs.resolve.outputs.comment_id }}
@@ -196,7 +196,7 @@ jobs:
         (needs.resolve.outputs.gate_conclusion == 'success' &&
          needs.pr_context.outputs.has_agent_label == 'true')
       )
-    uses: stranske/Workflows/.github/workflows/reusable-bot-comment-handler.yml@main
+    uses: iamkayleb/Workflows/.github/workflows/reusable-bot-comment-handler.yml@main
     with:
       pr_number: ${{ fromJSON(needs.resolve.outputs.pr_number) }}
       dry_run: ${{ needs.resolve.outputs.dry_run == 'true' }}
@@ -277,7 +277,7 @@ jobs:
         if: steps.check-merged.outputs.merged == 'true'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          repository: stranske/Workflows
+          repository: iamkayleb/Workflows
           token: ${{ secrets.CODESPACES_WORKFLOWS || github.token }}
           sparse-checkout: |
             scripts/langchain

--- a/templates/consumer-repo/.github/workflows/agents-81-gate-followups.yml
+++ b/templates/consumer-repo/.github/workflows/agents-81-gate-followups.yml
@@ -295,7 +295,7 @@ jobs:
       - mark-running
     # Only run for agent:codex label
     if: needs.evaluate.outputs.agent_type == 'codex'
-    uses: stranske/Workflows/.github/workflows/reusable-codex-run.yml@main
+    uses: iamkayleb/Workflows/.github/workflows/reusable-codex-run.yml@main
     secrets:
       CODEX_AUTH_JSON: ${{ secrets.CODEX_AUTH_JSON }}
       # Use dedicated KEEPALIVE_APP for isolated rate limit pool (5000/hr)
@@ -328,7 +328,7 @@ jobs:
       (needs.evaluate.outputs.action == 'run' ||
        needs.evaluate.outputs.action == 'fix' ||
        needs.evaluate.outputs.action == 'conflict')
-    uses: stranske/Workflows/.github/workflows/reusable-claude-run.yml@main
+    uses: iamkayleb/Workflows/.github/workflows/reusable-claude-run.yml@main
     secrets: inherit
     with:
       skip: >-
@@ -988,7 +988,7 @@ jobs:
       needs.prepare.outputs.should_run == 'true' &&
       needs.prepare.outputs.agent_type == 'codex'
     name: Run Codex autofix
-    uses: stranske/Workflows/.github/workflows/reusable-codex-run.yml@main
+    uses: iamkayleb/Workflows/.github/workflows/reusable-codex-run.yml@main
     with:
       prompt_file: .github/codex/prompts/autofix_from_ci_failure.md
       mode: autofix
@@ -1006,7 +1006,7 @@ jobs:
       needs.prepare.outputs.should_run == 'true' &&
       needs.prepare.outputs.agent_type == 'claude'
     name: Run Claude autofix
-    uses: stranske/Workflows/.github/workflows/reusable-claude-run.yml@main
+    uses: iamkayleb/Workflows/.github/workflows/reusable-claude-run.yml@main
     with:
       prompt_file: .github/codex/prompts/autofix_from_ci_failure.md
       mode: autofix

--- a/templates/consumer-repo/.github/workflows/agents-auto-pilot.yml
+++ b/templates/consumer-repo/.github/workflows/agents-auto-pilot.yml
@@ -190,7 +190,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           token: ${{ steps.app_token.outputs.token || github.token }}
-          repository: stranske/Workflows
+          repository: iamkayleb/Workflows
           ref: ${{ steps.workflows_ref.outputs.ref }}
           sparse-checkout: |
             .github/actions/setup-api-client

--- a/templates/consumer-repo/.github/workflows/agents-autofix-loop.yml
+++ b/templates/consumer-repo/.github/workflows/agents-autofix-loop.yml
@@ -590,7 +590,7 @@ jobs:
       needs.prepare.outputs.should_run == 'true' &&
       needs.prepare.outputs.agent_type == 'codex'
     name: Run Codex autofix
-    uses: stranske/Workflows/.github/workflows/reusable-codex-run.yml@main
+    uses: iamkayleb/Workflows/.github/workflows/reusable-codex-run.yml@main
     with:
       prompt_file: .github/codex/prompts/autofix_from_ci_failure.md
       mode: autofix
@@ -614,7 +614,7 @@ jobs:
       needs.prepare.outputs.should_run == 'true' &&
       needs.prepare.outputs.agent_type == 'claude'
     name: Run Claude autofix
-    uses: stranske/Workflows/.github/workflows/reusable-claude-run.yml@main
+    uses: iamkayleb/Workflows/.github/workflows/reusable-claude-run.yml@main
     with:
       prompt_file: .github/codex/prompts/autofix_from_ci_failure.md
       mode: autofix

--- a/templates/consumer-repo/.github/workflows/agents-bot-comment-handler.yml
+++ b/templates/consumer-repo/.github/workflows/agents-bot-comment-handler.yml
@@ -352,7 +352,7 @@ jobs:
     name: Handle bot comments
     needs: resolve
     if: vars.USE_CONSOLIDATED_WORKFLOWS != 'true' && needs.resolve.outputs.should_run == 'true'
-    uses: stranske/Workflows/.github/workflows/reusable-bot-comment-handler.yml@main
+    uses: iamkayleb/Workflows/.github/workflows/reusable-bot-comment-handler.yml@main
     with:
       pr_number: ${{ needs.resolve.outputs.pr_number }}
       dry_run: ${{ inputs.dry_run == true }}

--- a/templates/consumer-repo/.github/workflows/agents-guard.yml
+++ b/templates/consumer-repo/.github/workflows/agents-guard.yml
@@ -81,7 +81,7 @@ jobs:
         if: >-
           github.event_name == 'pull_request_target' &&
           steps.api_client_base.outputs.available != 'true'
-        uses: "stranske/Workflows/.github/actions/setup-api-client@6deed4d3937adab2370b4ddf96046ed295efe68f" # v1
+        uses: "iamkayleb/Workflows/.github/actions/setup-api-client@main"
         with:
           secrets: ${{ toJSON(secrets) }}
           github_token: ${{ github.token }}
@@ -137,7 +137,7 @@ jobs:
 
       - name: Setup API client (Workflows fallback)
         if: github.event_name == 'pull_request' && steps.api_client_head.outputs.available != 'true'
-        uses: "stranske/Workflows/.github/actions/setup-api-client@6deed4d3937adab2370b4ddf96046ed295efe68f" # v1
+        uses: "iamkayleb/Workflows/.github/actions/setup-api-client@main"
         with:
           secrets: ${{ toJSON(secrets) }}
           github_token: ${{ github.token }}

--- a/templates/consumer-repo/.github/workflows/agents-issue-intake.yml
+++ b/templates/consumer-repo/.github/workflows/agents-issue-intake.yml
@@ -179,7 +179,7 @@ jobs:
     if: |
       needs.route.outputs.should_run_bridge == 'true' &&
       needs.check_labels.outputs.should_run == 'true'
-    uses: stranske/Workflows/.github/workflows/reusable-agents-issue-bridge.yml@main
+    uses: iamkayleb/Workflows/.github/workflows/reusable-agents-issue-bridge.yml@main
     with:
       agent: ${{ needs.check_labels.outputs.agent }}
       issue_number: ${{ needs.check_labels.outputs.issue_number }}
@@ -208,7 +208,7 @@ jobs:
       id-token: write
       models: read
       pull-requests: write
-    uses: stranske/Workflows/.github/workflows/agents-63-issue-intake.yml@main
+    uses: iamkayleb/Workflows/.github/workflows/agents-63-issue-intake.yml@main
     with:
       intake_mode: "chatgpt_sync"
       source: ${{ inputs.topic_files }}

--- a/templates/consumer-repo/.github/workflows/agents-issue-optimizer.yml
+++ b/templates/consumer-repo/.github/workflows/agents-issue-optimizer.yml
@@ -123,7 +123,7 @@ jobs:
         if: steps.check.outputs.should_run == 'true'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          repository: stranske/Workflows
+          repository: iamkayleb/Workflows
           path: workflows-scripts
           sparse-checkout: |
             scripts/langchain

--- a/templates/consumer-repo/.github/workflows/agents-keepalive-loop.yml
+++ b/templates/consumer-repo/.github/workflows/agents-keepalive-loop.yml
@@ -539,7 +539,7 @@ jobs:
       (needs.evaluate.outputs.action == 'run' ||
        needs.evaluate.outputs.action == 'fix' ||
        needs.evaluate.outputs.action == 'conflict')
-    uses: stranske/Workflows/.github/workflows/reusable-codex-run.yml@main
+    uses: iamkayleb/Workflows/.github/workflows/reusable-codex-run.yml@main
     secrets: inherit
     with:
       skip: >-
@@ -571,7 +571,7 @@ jobs:
       (needs.evaluate.outputs.action == 'run' ||
        needs.evaluate.outputs.action == 'fix' ||
        needs.evaluate.outputs.action == 'conflict')
-    uses: stranske/Workflows/.github/workflows/reusable-claude-run.yml@main
+    uses: iamkayleb/Workflows/.github/workflows/reusable-claude-run.yml@main
     secrets: inherit
     with:
       skip: >-

--- a/templates/consumer-repo/.github/workflows/agents-orchestrator.yml
+++ b/templates/consumer-repo/.github/workflows/agents-orchestrator.yml
@@ -58,7 +58,7 @@ concurrency:
 jobs:
   orchestrate:
     name: Agent Orchestration
-    uses: stranske/Workflows/.github/workflows/reusable-16-agents.yml@main
+    uses: iamkayleb/Workflows/.github/workflows/reusable-16-agents.yml@main
     with:
       # Readiness/bootstrap default to false (opt-in)
       enable_readiness: ${{ inputs.enable_readiness && 'true' || 'false' }}

--- a/templates/consumer-repo/.github/workflows/agents-pr-health.yml
+++ b/templates/consumer-repo/.github/workflows/agents-pr-health.yml
@@ -52,7 +52,7 @@ concurrency:
 
 jobs:
   health:
-    uses: stranske/Workflows/.github/workflows/reusable-agents-pr-health.yml@main
+    uses: iamkayleb/Workflows/.github/workflows/reusable-agents-pr-health.yml@main
     with:
       dry_run: ${{ inputs.dry_run && 'true' || 'false' }}
       max_prs: ${{ inputs.max_prs || '10' }}

--- a/templates/consumer-repo/.github/workflows/agents-pr-meta.yml
+++ b/templates/consumer-repo/.github/workflows/agents-pr-meta.yml
@@ -75,7 +75,7 @@ jobs:
             core.setOutput('pr_number', pr.number);
             core.setOutput('comment_id', comment.id);
             // Encode comment body as Base64 to safely handle multiline and special characters.
-            // The reusable workflow at stranske/Workflows/.github/workflows/reusable-20-pr-meta.yml
+            // The reusable workflow at iamkayleb/Workflows/.github/workflows/reusable-20-pr-meta.yml
             // expects this value to be Base64-encoded and is responsible for decoding it.
             core.setOutput('comment_body', Buffer.from(comment.body || '').toString('base64'));
 
@@ -86,7 +86,7 @@ jobs:
       vars.USE_CONSOLIDATED_WORKFLOWS != 'true' &&
       github.event_name == 'issue_comment' &&
       github.event.issue.pull_request
-    uses: stranske/Workflows/.github/workflows/reusable-20-pr-meta.yml@main
+    uses: iamkayleb/Workflows/.github/workflows/reusable-20-pr-meta.yml@main
     with:
       pr_number: ${{ fromJSON(needs.resolve_pr.outputs.pr_number) }}
       comment_id: ${{ needs.resolve_pr.outputs.comment_id }}
@@ -100,7 +100,7 @@ jobs:
   # Call reusable PR meta workflow for PR events
   pr_meta_pr:
     if: vars.USE_CONSOLIDATED_WORKFLOWS != 'true' && github.event_name == 'pull_request'
-    uses: stranske/Workflows/.github/workflows/reusable-20-pr-meta.yml@main
+    uses: iamkayleb/Workflows/.github/workflows/reusable-20-pr-meta.yml@main
     with:
       pr_number: ${{ github.event.pull_request.number }}
       event_name: 'pull_request'
@@ -137,7 +137,7 @@ jobs:
       vars.USE_CONSOLIDATED_WORKFLOWS != 'true' &&
       github.event_name == 'workflow_run' &&
       needs.resolve_pr_from_workflow_run.outputs.should_run == 'true'
-    uses: stranske/Workflows/.github/workflows/reusable-20-pr-meta.yml@main
+    uses: iamkayleb/Workflows/.github/workflows/reusable-20-pr-meta.yml@main
     with:
       pr_number: ${{ fromJSON(needs.resolve_pr_from_workflow_run.outputs.pr_number) }}
       event_name: 'workflow_run'

--- a/templates/consumer-repo/.github/workflows/agents-verifier.yml
+++ b/templates/consumer-repo/.github/workflows/agents-verifier.yml
@@ -203,7 +203,7 @@ jobs:
   verifier:
     needs: check
     if: needs.check.outputs.should_run == 'true'
-    uses: stranske/Workflows/.github/workflows/reusable-agents-verifier.yml@main
+    uses: iamkayleb/Workflows/.github/workflows/reusable-agents-verifier.yml@main
     with:
       # CI workflows to wait for before running verifier
       ci_workflows: '["ci.yml", "pr-00-gate.yml"]'

--- a/templates/consumer-repo/.github/workflows/agents-verify-to-issue-v2.yml
+++ b/templates/consumer-repo/.github/workflows/agents-verify-to-issue-v2.yml
@@ -70,7 +70,7 @@ jobs:
         if: steps.check-merged.outputs.merged == 'true'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          repository: stranske/Workflows
+          repository: iamkayleb/Workflows
           token: ${{ steps.select-token.outputs.token }}
           sparse-checkout: |
             .github/actions/setup-api-client

--- a/templates/consumer-repo/.github/workflows/agents-verify-to-new-pr.yml
+++ b/templates/consumer-repo/.github/workflows/agents-verify-to-new-pr.yml
@@ -72,7 +72,7 @@ jobs:
         if: steps.check-merged.outputs.merged == 'true'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          repository: stranske/Workflows
+          repository: iamkayleb/Workflows
           token: ${{ steps.select-token.outputs.token }}
           sparse-checkout: |
             .github/actions/setup-api-client

--- a/templates/consumer-repo/.github/workflows/autofix.yml
+++ b/templates/consumer-repo/.github/workflows/autofix.yml
@@ -546,7 +546,7 @@ jobs:
   autofix:
     needs: resolve
     if: needs.resolve.outputs.should_run == 'true'
-    uses: stranske/Workflows/.github/workflows/reusable-18-autofix.yml@main
+    uses: iamkayleb/Workflows/.github/workflows/reusable-18-autofix.yml@main
     with:
       pr_number: ${{ fromJson(needs.resolve.outputs.pr_number) }}
       pr_head_ref: ${{ needs.resolve.outputs.pr_head_ref }}

--- a/templates/consumer-repo/.github/workflows/ci.yml
+++ b/templates/consumer-repo/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 # Thin caller for Python CI - delegates to Workflows repo reusable workflow
-# No local scripts required - all logic is centralized in stranske/Workflows
+# No local scripts required - all logic is centralized in iamkayleb/Workflows
 #
 # This workflow runs:
 # - Lint (Ruff)
@@ -25,7 +25,7 @@ on:
 jobs:
   python:
     name: Python CI
-    uses: stranske/Workflows/.github/workflows/reusable-10-ci-python.yml@main
+    uses: iamkayleb/Workflows/.github/workflows/reusable-10-ci-python.yml@main
     with:
       python-versions: '["3.11", "3.12"]'
       typecheck: true

--- a/templates/consumer-repo/.github/workflows/pr-00-gate.yml
+++ b/templates/consumer-repo/.github/workflows/pr-00-gate.yml
@@ -126,7 +126,7 @@ jobs:
       - detect
       - environment-gate
     if: ${{ needs.detect.outputs.doc_only != 'true' && needs.detect.outputs.run_core == 'true' }}
-    uses: stranske/Workflows/.github/workflows/reusable-10-ci-python.yml@main
+    uses: iamkayleb/Workflows/.github/workflows/reusable-10-ci-python.yml@main
     secrets: inherit
     permissions:
       contents: read
@@ -225,7 +225,7 @@ jobs:
         fromJSON(needs.detect.outputs.run_core || 'true') &&
         fromJSON(needs.detect.outputs.docker_changed || 'false')
       }}
-    uses: stranske/Workflows/.github/workflows/reusable-12-ci-docker.yml@main
+    uses: iamkayleb/Workflows/.github/workflows/reusable-12-ci-docker.yml@main
 
   ledger-validation:
     name: ledger validation

--- a/templates/consumer-repo/AGENTS.md
+++ b/templates/consumer-repo/AGENTS.md
@@ -4,15 +4,15 @@
 
 ## This Is A Consumer Repo
 
-Most workflow logic for this repository lives in `stranske/Workflows`. The consumer repo should only carry repo-specific configuration unless it has an explicitly documented exception.
+Most workflow logic for this repository lives in `iamkayleb/Workflows`. The consumer repo should only carry repo-specific configuration unless it has an explicitly documented exception.
 
 ## Source Of Truth
 
 For infrastructure work, follow this order:
 
-1. `stranske/Workflows` root docs: `README.md`, `docs/WORKFLOW_GUIDE.md`, `docs/ci/WORKFLOWS.md`
-2. `stranske/Workflows/docs/INTEGRATION_GUIDE.md` and `docs/ops/CONSUMER_REPO_MAINTENANCE.md`
-3. The consumer sync source in `stranske/Workflows/templates/consumer-repo/`
+1. `iamkayleb/Workflows` root docs: `README.md`, `docs/WORKFLOW_GUIDE.md`, `docs/ci/WORKFLOWS.md`
+2. `iamkayleb/Workflows/docs/INTEGRATION_GUIDE.md` and `docs/ops/CONSUMER_REPO_MAINTENANCE.md`
+3. The consumer sync source in `iamkayleb/Workflows/templates/consumer-repo/`
 4. This repo's local repo-specific files
 
 If a file is synced from Workflows, fix it in Workflows first.
@@ -56,7 +56,7 @@ Legacy compatibility workflows may still exist during migrations. Do not assume 
 
 Before editing local workflow infrastructure, ask:
 
-**Does this work belong in `stranske/Workflows` instead?**
+**Does this work belong in `iamkayleb/Workflows` instead?**
 
 The answer is usually yes if the change affects any of these:
 
@@ -68,18 +68,18 @@ The answer is usually yes if the change affects any of these:
 
 If yes:
 
-1. Make the source-of-truth change in `stranske/Workflows`
+1. Make the source-of-truth change in `iamkayleb/Workflows`
 2. Update the sync manifest if a consumer-facing file changed
 3. Sync or manually align this repo afterward
 
 ## Useful References
 
-- `stranske/Workflows/README.md`
-- `stranske/Workflows/docs/WORKFLOW_GUIDE.md`
-- `stranske/Workflows/docs/ci/WORKFLOWS.md`
-- `stranske/Workflows/docs/INTEGRATION_GUIDE.md`
-- `stranske/Workflows/docs/ops/CONSUMER_REPO_MAINTENANCE.md`
-- `stranske/Workflows/docs/keepalive/Agents.md`
+- `iamkayleb/Workflows/README.md`
+- `iamkayleb/Workflows/docs/WORKFLOW_GUIDE.md`
+- `iamkayleb/Workflows/docs/ci/WORKFLOWS.md`
+- `iamkayleb/Workflows/docs/INTEGRATION_GUIDE.md`
+- `iamkayleb/Workflows/docs/ops/CONSUMER_REPO_MAINTENANCE.md`
+- `iamkayleb/Workflows/docs/keepalive/Agents.md`
 - `stranske/Travel-Plan-Permission` as a reference consumer
 
 ## Agent-Specific Note

--- a/templates/consumer-repo/CLAUDE.md
+++ b/templates/consumer-repo/CLAUDE.md
@@ -4,15 +4,15 @@
 
 ## This Is A Consumer Repo
 
-Most workflow logic for this repository lives in `stranske/Workflows`. The consumer repo should only carry repo-specific configuration unless it has an explicitly documented exception.
+Most workflow logic for this repository lives in `iamkayleb/Workflows`. The consumer repo should only carry repo-specific configuration unless it has an explicitly documented exception.
 
 ## Source Of Truth
 
 For infrastructure work, follow this order:
 
-1. `stranske/Workflows` root docs: `README.md`, `docs/WORKFLOW_GUIDE.md`, `docs/ci/WORKFLOWS.md`
-2. `stranske/Workflows/docs/INTEGRATION_GUIDE.md` and `docs/ops/CONSUMER_REPO_MAINTENANCE.md`
-3. The consumer sync source in `stranske/Workflows/templates/consumer-repo/`
+1. `iamkayleb/Workflows` root docs: `README.md`, `docs/WORKFLOW_GUIDE.md`, `docs/ci/WORKFLOWS.md`
+2. `iamkayleb/Workflows/docs/INTEGRATION_GUIDE.md` and `docs/ops/CONSUMER_REPO_MAINTENANCE.md`
+3. The consumer sync source in `iamkayleb/Workflows/templates/consumer-repo/`
 4. This repo's local repo-specific files
 
 If a file is synced from Workflows, fix it in Workflows first.
@@ -56,7 +56,7 @@ Legacy compatibility workflows may still exist during migrations. Do not assume 
 
 Before editing local workflow infrastructure, ask:
 
-**Does this work belong in `stranske/Workflows` instead?**
+**Does this work belong in `iamkayleb/Workflows` instead?**
 
 The answer is usually yes if the change affects any of these:
 
@@ -68,18 +68,18 @@ The answer is usually yes if the change affects any of these:
 
 If yes:
 
-1. Make the source-of-truth change in `stranske/Workflows`
+1. Make the source-of-truth change in `iamkayleb/Workflows`
 2. Update the sync manifest if a consumer-facing file changed
 3. Sync or manually align this repo afterward
 
 ## Useful References
 
-- `stranske/Workflows/README.md`
-- `stranske/Workflows/docs/WORKFLOW_GUIDE.md`
-- `stranske/Workflows/docs/ci/WORKFLOWS.md`
-- `stranske/Workflows/docs/INTEGRATION_GUIDE.md`
-- `stranske/Workflows/docs/ops/CONSUMER_REPO_MAINTENANCE.md`
-- `stranske/Workflows/docs/keepalive/Agents.md`
+- `iamkayleb/Workflows/README.md`
+- `iamkayleb/Workflows/docs/WORKFLOW_GUIDE.md`
+- `iamkayleb/Workflows/docs/ci/WORKFLOWS.md`
+- `iamkayleb/Workflows/docs/INTEGRATION_GUIDE.md`
+- `iamkayleb/Workflows/docs/ops/CONSUMER_REPO_MAINTENANCE.md`
+- `iamkayleb/Workflows/docs/keepalive/Agents.md`
 - `stranske/Travel-Plan-Permission` as a reference consumer
 
 ## Claude-Specific Note

--- a/templates/consumer-repo/README.md
+++ b/templates/consumer-repo/README.md
@@ -70,8 +70,8 @@ steps:
   - name: Checkout Workflows scripts
     uses: actions/checkout@v6
     with:
-      repository: stranske/Workflows
-         # Keep this aligned with the ref you use in `uses: stranske/Workflows/...@<ref>`.
+      repository: iamkayleb/Workflows
+         # Keep this aligned with the ref you use in `uses: iamkayleb/Workflows/...@<ref>`.
          # Prefer stable tags (`v1`) for most consumers.
          ref: v1
       sparse-checkout: .github/scripts


### PR DESCRIPTION
…ayleb/Workflows

The autofix loop and several other workflows still referenced stranske/Workflows for reusable workflow calls. This meant fixes to reusable-claude-run.yml (GITHUB_TOKEN unbound variable fix) were not picked up by the autofix chain, causing the Claude runner to keep failing despite the fix being on main.

Updated all uses: declarations and setup-api-client references in both in-repo workflows and consumer templates. Also reverted pr-00-gate.yml sync_mode to create_only and added Claude runner troubleshooting docs (Part 5).

https://claude.ai/code/session_01FC8XoyssN5v6hQCTtcjoB5