### PR TITLE
fix(keepalive): add Gemini preflight secrets check

### DIFF
--- a/templates/consumer-repo/.github/workflows/agents-keepalive-loop.yml
+++ b/templates/consumer-repo/.github/workflows/agents-keepalive-loop.yml
@@ -412,6 +412,7 @@ jobs:
           HAS_CODEX_AUTH: ${{ secrets.CODEX_AUTH_JSON != '' }}
           HAS_CLAUDE_AUTH: ${{ secrets.CLAUDE_AUTH_JSON != '' }}
           HAS_CLAUDE_OAUTH: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN != '' }}
+          HAS_GEMINI_AUTH: ${{ secrets.GEMINI_API_KEY != '' }}
           AGENT_TYPE: ${{ needs.evaluate.outputs.agent_type || 'codex' }}
           HAS_APP_ID: >-
             ${{ secrets.KEEPALIVE_APP_ID != '' ||
@@ -424,6 +425,7 @@ jobs:
           echo "CODEX_AUTH_JSON present: $HAS_CODEX_AUTH"
           echo "CLAUDE_AUTH_JSON present: $HAS_CLAUDE_AUTH"
           echo "CLAUDE_CODE_OAUTH_TOKEN present: $HAS_CLAUDE_OAUTH"
+          echo "GEMINI_API_KEY present: $HAS_GEMINI_AUTH"
           echo "KEEPALIVE_APP or WORKFLOWS_APP present: $HAS_APP_ID"
           echo "WORKFLOWS_APP_PRIVATE_KEY present: $HAS_APP_KEY"
           agent_auth_ok=false
@@ -438,8 +440,13 @@ jobs:
                 agent_auth_ok=true
               fi
               ;;
+            gemini)
+              if [ "$HAS_GEMINI_AUTH" = "true" ]; then
+                agent_auth_ok=true
+              fi
+              ;;
             *)
-              if [ "$HAS_CODEX_AUTH" = "true" ] || [ "$HAS_CLAUDE_AUTH" = "true" ] || [ "$HAS_CLAUDE_OAUTH" = "true" ]; then
+              if [ "$HAS_CODEX_AUTH" = "true" ] || [ "$HAS_CLAUDE_AUTH" = "true" ] || [ "$HAS_CLAUDE_OAUTH" = "true" ] || [ "$HAS_GEMINI_AUTH" = "true" ]; then
                 agent_auth_ok=true
               fi
               ;;
@@ -454,6 +461,9 @@ jobs:
                 ;;
               codex)
                 missing_msg="Missing credentials for agent 'codex'. Set CODEX_AUTH_JSON, or configure KEEPALIVE/WORKFLOWS_APP credentials."
+                ;;
+              gemini)
+                missing_msg="Missing credentials for agent 'gemini'. Set GEMINI_API_KEY (from https://aistudio.google.com/apikey), or configure KEEPALIVE/WORKFLOWS_APP credentials."
                 ;;
               *)
                 missing_msg="Missing credentials for agent '${AGENT_TYPE}'. Configure that agent's credentials or KEEPALIVE/WORKFLOWS_APP credentials."


### PR DESCRIPTION
The preflight secrets check only handled codex and claude agents. When agent_type is 'gemini', add a check for GEMINI_API_KEY and a proper error message guiding users to aistudio.google.com/apikey.

https://claude.ai/code/session_01FC8XoyssN5v6hQCTtcjoB5