### PR TITLE
fix(intake): add permissions for bridge job

### DIFF
--- a/templates/consumer-repo/.github/workflows/agents-issue-intake.yml
+++ b/templates/consumer-repo/.github/workflows/agents-issue-intake.yml
@@ -176,6 +176,10 @@ jobs:
   # Agent bridge mode: Call the Workflows repo reusable issue bridge
   bridge:
     needs: [route, check_labels]
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
     if: |
       needs.route.outputs.should_run_bridge == 'true' &&
       needs.check_labels.outputs.should_run == 'true'


### PR DESCRIPTION
The bridge job calls reusable-agents-issue-bridge.yml which needs contents: write, issues: write, pull-requests: write. Without an explicit permissions block on the caller job, repos with restrictive default token permissions reject the call at parse time.

https://claude.ai/code/session_01FC8XoyssN5v6hQCTtcjoB5