### PR TITLE
feat(gate-followups): add full Gemini agent support to active keepali…

### DIFF
--- a/templates/consumer-repo/.github/workflows/agents-81-gate-followups.yml
+++ b/templates/consumer-repo/.github/workflows/agents-81-gate-followups.yml
@@ -212,22 +212,53 @@ jobs:
           HAS_CODEX_AUTH: ${{ secrets.CODEX_AUTH_JSON != '' }}
           HAS_CLAUDE_AUTH: ${{ secrets.CLAUDE_AUTH_JSON != '' }}
           HAS_CLAUDE_OAUTH: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN != '' }}
+          HAS_GEMINI_AUTH: ${{ secrets.GEMINI_API_KEY != '' }}
           HAS_APP_ID: >-
             ${{ secrets.KEEPALIVE_APP_ID != '' ||
                 secrets.WORKFLOWS_APP_ID != '' }}
           HAS_APP_KEY: >-
             ${{ secrets.KEEPALIVE_APP_PRIVATE_KEY != '' ||
                 secrets.WORKFLOWS_APP_PRIVATE_KEY != '' }}
+          AGENT_TYPE: ${{ needs.evaluate.outputs.agent_type }}
         run: |
           echo "CODEX_AUTH_JSON present: $HAS_CODEX_AUTH"
           echo "CLAUDE_AUTH_JSON present: $HAS_CLAUDE_AUTH"
           echo "CLAUDE_CODE_OAUTH_TOKEN present: $HAS_CLAUDE_OAUTH"
+          echo "GEMINI_API_KEY present: $HAS_GEMINI_AUTH"
           echo "KEEPALIVE_APP or WORKFLOWS_APP present: $HAS_APP_ID"
           echo "WORKFLOWS_APP_PRIVATE_KEY present: $HAS_APP_KEY"
-          if [ "$HAS_CODEX_AUTH" = "true" ] || [ "$HAS_CLAUDE_AUTH" = "true" ] || [ "$HAS_CLAUDE_OAUTH" = "true" ] || [ "$HAS_APP_ID" = "true" ]; then
+          echo "Agent type: $AGENT_TYPE"
+
+          # Agent-specific auth check
+          agent_auth_ok=false
+          case "$AGENT_TYPE" in
+            codex)
+              if [ "$HAS_CODEX_AUTH" = "true" ] || [ "$HAS_APP_ID" = "true" ]; then
+                agent_auth_ok=true
+              fi
+              ;;
+            claude)
+              if [ "$HAS_CLAUDE_AUTH" = "true" ] || [ "$HAS_CLAUDE_OAUTH" = "true" ]; then
+                agent_auth_ok=true
+              fi
+              ;;
+            gemini)
+              if [ "$HAS_GEMINI_AUTH" = "true" ]; then
+                agent_auth_ok=true
+              fi
+              ;;
+            *)
+              # Unknown agent - fall back to any auth available
+              if [ "$HAS_CODEX_AUTH" = "true" ] || [ "$HAS_CLAUDE_AUTH" = "true" ] || [ "$HAS_CLAUDE_OAUTH" = "true" ] || [ "$HAS_GEMINI_AUTH" = "true" ] || [ "$HAS_APP_ID" = "true" ]; then
+                agent_auth_ok=true
+              fi
+              ;;
+          esac
+
+          if [ "$agent_auth_ok" = "true" ]; then
             echo "secrets_ok=true" >> "$GITHUB_OUTPUT"
           else
-            echo "::error::No agent auth found. Set CLAUDE_CODE_OAUTH_TOKEN (preferred), CODEX_AUTH_JSON, CLAUDE_AUTH_JSON, or KEEPALIVE/WORKFLOWS_APP."
+            echo "::error::No auth found for agent '$AGENT_TYPE'. Set the appropriate secret (GEMINI_API_KEY for gemini, CLAUDE_CODE_OAUTH_TOKEN for claude, CODEX_AUTH_JSON for codex)."
             echo "secrets_ok=false" >> "$GITHUB_OUTPUT"
             exit 1
           fi
@@ -342,6 +373,31 @@ jobs:
       appendix: ${{ needs.evaluate.outputs.task_appendix }}
       iteration: ${{ needs.evaluate.outputs.iteration }}
 
+  run-gemini:
+    name: Keepalive next task (Gemini)
+    needs:
+      - evaluate
+      - preflight
+      - mark-running
+    if: |
+      needs.evaluate.outputs.agent_type == 'gemini' &&
+      (needs.evaluate.outputs.action == 'run' ||
+       needs.evaluate.outputs.action == 'fix' ||
+       needs.evaluate.outputs.action == 'conflict')
+    uses: iamkayleb/Workflows/.github/workflows/reusable-gemini-run.yml@main
+    secrets: inherit
+    with:
+      skip: >-
+        ${{ needs.evaluate.outputs.action != 'run' &&
+            needs.evaluate.outputs.action != 'fix' &&
+            needs.evaluate.outputs.action != 'conflict' }}
+      prompt_file: ${{ needs.evaluate.outputs.prompt_file }}
+      mode: keepalive
+      pr_number: ${{ needs.evaluate.outputs.pr_number }}
+      pr_ref: ${{ needs.evaluate.outputs.pr_ref }}
+      appendix: ${{ needs.evaluate.outputs.task_appendix }}
+      iteration: ${{ needs.evaluate.outputs.iteration }}
+
   summary:
     name: Update keepalive summary
     needs:
@@ -349,6 +405,7 @@ jobs:
       - preflight
       - run-codex
       - run-claude
+      - run-gemini
     # Run always if PR exists, handle skipped agent jobs gracefully
     if: |
       always() &&
@@ -444,13 +501,15 @@ jobs:
       - name: Auto-reconcile task checkboxes
         if: |
           needs.run-codex.outputs.changes-made == 'true' ||
-          needs.run-claude.outputs.changes-made == 'true'
+          needs.run-claude.outputs.changes-made == 'true' ||
+          needs.run-gemini.outputs.changes-made == 'true'
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           LLM_COMPLETED_TASKS: >-
             ${{
               needs.run-codex.outputs.llm-completed-tasks ||
               needs.run-claude.outputs.llm-completed-tasks ||
+              needs.run-gemini.outputs.llm-completed-tasks ||
               '[]'
             }}
         with:
@@ -462,20 +521,24 @@ jobs:
             const beforeSha = '${{ needs.evaluate.outputs.head_sha }}';  // SHA before agent ran
             const headSha =
               '${{ needs.run-codex.outputs.commit-sha }}' ||
-              '${{ needs.run-claude.outputs.commit-sha }}';
+              '${{ needs.run-claude.outputs.commit-sha }}' ||
+              '${{ needs.run-gemini.outputs.commit-sha }}';
 
             // LLM analysis metadata
             const llmProvider =
               '${{ needs.run-codex.outputs.llm-provider }}' ||
               '${{ needs.run-claude.outputs.llm-provider }}' ||
+              '${{ needs.run-gemini.outputs.llm-provider }}' ||
               '';
             const llmConfidence =
               '${{ needs.run-codex.outputs.llm-confidence }}' ||
               '${{ needs.run-claude.outputs.llm-confidence }}' ||
+              '${{ needs.run-gemini.outputs.llm-confidence }}' ||
               '';
             const llmAnalysisRun =
               '${{ needs.run-codex.outputs.llm-analysis-run }}' === 'true' ||
-              '${{ needs.run-claude.outputs.llm-analysis-run }}' === 'true';
+              '${{ needs.run-claude.outputs.llm-analysis-run }}' === 'true' ||
+              '${{ needs.run-gemini.outputs.llm-analysis-run }}' === 'true';
 
               // Parse LLM completed tasks if available
               // Use env var to avoid JS string escaping issues
@@ -528,8 +591,10 @@ jobs:
             ${{
               needs.run-codex.outputs.final-message-summary ||
               needs.run-claude.outputs.final-message-summary ||
+              needs.run-gemini.outputs.final-message-summary ||
               needs.run-codex.outputs.error-summary ||
               needs.run-claude.outputs.error-summary ||
+              needs.run-gemini.outputs.error-summary ||
               ''
             }}
         with:
@@ -540,33 +605,43 @@ jobs:
 
             const claudeResult = '${{ needs.run-claude.result }}';
             const codexResult = '${{ needs.run-codex.result }}';
+            const geminiResult = '${{ needs.run-gemini.result }}';
             const runResult =
-              claudeResult && claudeResult !== 'skipped' ? claudeResult : codexResult;
+              claudeResult && claudeResult !== 'skipped' ? claudeResult :
+              geminiResult && geminiResult !== 'skipped' ? geminiResult :
+              codexResult;
 
             const agentExitCode =
               '${{ needs.run-codex.outputs.exit-code }}' ||
-              '${{ needs.run-claude.outputs.exit-code }}';
+              '${{ needs.run-claude.outputs.exit-code }}' ||
+              '${{ needs.run-gemini.outputs.exit-code }}';
             const agentChangesMade =
               '${{ needs.run-codex.outputs.changes-made }}' ||
-              '${{ needs.run-claude.outputs.changes-made }}';
+              '${{ needs.run-claude.outputs.changes-made }}' ||
+              '${{ needs.run-gemini.outputs.changes-made }}';
             const agentCommitSha =
               '${{ needs.run-codex.outputs.commit-sha }}' ||
-              '${{ needs.run-claude.outputs.commit-sha }}';
+              '${{ needs.run-claude.outputs.commit-sha }}' ||
+              '${{ needs.run-gemini.outputs.commit-sha }}';
             const agentFilesChanged =
               '${{ needs.run-codex.outputs.files-changed }}' ||
-              '${{ needs.run-claude.outputs.files-changed }}';
+              '${{ needs.run-claude.outputs.files-changed }}' ||
+              '${{ needs.run-gemini.outputs.files-changed }}';
 
             const llmProvider =
               '${{ needs.run-codex.outputs.llm-provider }}' ||
               '${{ needs.run-claude.outputs.llm-provider }}' ||
+              '${{ needs.run-gemini.outputs.llm-provider }}' ||
               '';
             const llmConfidence =
               '${{ needs.run-codex.outputs.llm-confidence }}' ||
               '${{ needs.run-claude.outputs.llm-confidence }}' ||
+              '${{ needs.run-gemini.outputs.llm-confidence }}' ||
               '';
             const llmAnalysisRun =
               '${{ needs.run-codex.outputs.llm-analysis-run }}' === 'true' ||
-              '${{ needs.run-claude.outputs.llm-analysis-run }}' === 'true';
+              '${{ needs.run-claude.outputs.llm-analysis-run }}' === 'true' ||
+              '${{ needs.run-gemini.outputs.llm-analysis-run }}' === 'true';
 
             const inputs = {
               pr_number: Number('${{ needs.evaluate.outputs.pr_number }}') || 0,
@@ -1019,6 +1094,24 @@ jobs:
       WORKFLOWS_APP_ID: ${{ secrets.WORKFLOWS_APP_ID }}
       WORKFLOWS_APP_PRIVATE_KEY: ${{ secrets.WORKFLOWS_APP_PRIVATE_KEY }}
 
+  autofix-gemini:
+    needs: prepare
+    if: >-
+      needs.prepare.outputs.should_run == 'true' &&
+      needs.prepare.outputs.agent_type == 'gemini'
+    name: Run Gemini autofix
+    uses: iamkayleb/Workflows/.github/workflows/reusable-gemini-run.yml@main
+    with:
+      prompt_file: .github/codex/prompts/autofix_from_ci_failure.md
+      mode: autofix
+      pr_number: ${{ needs.prepare.outputs.pr_number }}
+      pr_ref: ${{ needs.prepare.outputs.head_ref }}
+      appendix: ${{ needs.prepare.outputs.appendix }}
+    secrets:
+      GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+      WORKFLOWS_APP_ID: ${{ secrets.WORKFLOWS_APP_ID }}
+      WORKFLOWS_APP_PRIVATE_KEY: ${{ secrets.WORKFLOWS_APP_PRIVATE_KEY }}
+
   needs-human:
     needs: prepare
     if: needs.prepare.outputs.stop_reason == 'max_attempts'
@@ -1092,6 +1185,7 @@ jobs:
       - prepare
       - autofix
       - autofix-claude
+      - autofix-gemini
     if: always()
     runs-on: ubuntu-latest
     environment: agent-standard
@@ -1136,10 +1230,13 @@ jobs:
             const stopReason = '${{ needs.prepare.outputs.stop_reason }}';
             const codexAutofixResult = '${{ needs.autofix.result }}';
             const claudeAutofixResult = '${{ needs.autofix-claude.result }}';
+            const geminiAutofixResult = '${{ needs.autofix-gemini.result }}';
             const autofixResult =
               codexAutofixResult && codexAutofixResult !== 'skipped'
                 ? codexAutofixResult
-                : claudeAutofixResult;
+                : claudeAutofixResult && claudeAutofixResult !== 'skipped'
+                  ? claudeAutofixResult
+                  : geminiAutofixResult;
 
             const { owner, repo } = context.repo;
             let fixApplied = false;


### PR DESCRIPTION
…ve workflow

The root cause of persistent "agent-run-skipped" was that Gemini support was only added to the deprecated agents-keepalive-loop.yml, not to agents-81-gate-followups.yml which is the actual active workflow.

Changes:
- Add run-gemini keepalive job calling reusable-gemini-run.yml
- Add autofix-gemini job for CI failure autofix
- Add agent-specific preflight secrets check (gemini checks GEMINI_API_KEY)
- Add run-gemini to summary job needs and all output collection points
- Add autofix-gemini to metrics job needs and autofixResult logic

https://claude.ai/code/session_01FC8XoyssN5v6hQCTtcjoB5