### PR TITLE
fix(gemini-runner): fix bash syntax error in commit step git reset

### DIFF
--- a/.github/workflows/reusable-gemini-run.yml
+++ b/.github/workflows/reusable-gemini-run.yml
@@ -1039,7 +1039,7 @@ jobs:
             node_modules \
             coverage.xml \
             pr_body.md \
-            Gemini (keepalive|autofix|verifier)_report_enriched.json \
+            autofix_report_enriched.json \
             poetry.lock \
             2>/dev/null || true
 


### PR DESCRIPTION
The pattern `Gemini (keepalive|autofix|verifier)_report_enriched.json` was passed unquoted to `git reset HEAD --`, causing bash to interpret the parenthesis as a syntax error (line 137 of the generated script).

Replace with `autofix_report_enriched.json` to match the Codex and Claude runners.

https://claude.ai/code/session_01FC8XoyssN5v6hQCTtcjoB5