### PR TITLE
fix(verify-to-new-pr): remove dangling && from template if-conditions

### DIFF
--- a/templates/consumer-repo/.github/workflows/agents-verify-to-new-pr.yml
+++ b/templates/consumer-repo/.github/workflows/agents-verify-to-new-pr.yml
@@ -421,7 +421,7 @@ jobs:
         id: generate
         if: >-
           steps.check-merged.outputs.merged == 'true' &&
-          steps.chain-check.outputs.exceeded != 'true' &&
+          steps.chain-check.outputs.exceeded != 'true'
         continue-on-error: true
         env:
           PYTHONPATH: ${{ github.workspace }}
@@ -466,7 +466,7 @@ jobs:
         if: >-
           steps.generate.outcome == 'failure' &&
           steps.check-merged.outputs.merged == 'true' &&
-          steps.chain-check.outputs.exceeded != 'true' &&
+          steps.chain-check.outputs.exceeded != 'true'
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           FOLLOW_UP_DEPTH: ${{ steps.chain-check.outputs.next_depth }}
@@ -637,7 +637,7 @@ jobs:
         id: create-issue
         if: >-
           steps.check-merged.outputs.merged == 'true' &&
-          steps.chain-check.outputs.exceeded != 'true' &&
+          steps.chain-check.outputs.exceeded != 'true'
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           ISSUE_TITLE: >-
@@ -767,7 +767,7 @@ jobs:
       - name: Comment on original PR
         if: >-
           steps.check-merged.outputs.merged == 'true' &&
-          steps.chain-check.outputs.exceeded != 'true' &&
+          steps.chain-check.outputs.exceeded != 'true'
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           ISSUE_NUMBER: ${{ steps.create-issue.outputs.issue_number }}


### PR DESCRIPTION
The previous commit (bb62b44) removed the needs_human gate from 4 step conditions but left trailing && operators, producing invalid GitHub Actions expressions. This fixes all 4 occurrences in the consumer template.

https://claude.ai/code/session_01FC8XoyssN5v6hQCTtcjoB5