### PR TITLE
feat(registry): add model field and wire Claude runner to use it

### DIFF
--- a/.github/agents/registry.yml
+++ b/.github/agents/registry.yml
@@ -28,6 +28,7 @@ agents:
 
   claude:
     display_name: Claude
+    model: claude-opus-4-7
     runner_workflow: .github/workflows/reusable-claude-run.yml
     required_secrets:
       - CLAUDE_CODE_OAUTH_TOKEN  # preferred: long-lived token from `claude setup-token`

--- a/.github/scripts/__tests__/agent-registry.test.js
+++ b/.github/scripts/__tests__/agent-registry.test.js
@@ -8,6 +8,7 @@ const os = require('node:os');
 
 const {
   getAgentConfig,
+  getAgentModel,
   getRunnerWorkflow,
   loadAgentRegistry,
   parseRegistryYaml,
@@ -163,6 +164,16 @@ test('getAgentConfig returns config for codex', () => {
 test('getRunnerWorkflow returns configured workflow path', () => {
   const workflow = getRunnerWorkflow('codex', { registryPath: REGISTRY_PATH });
   assert.equal(workflow, '.github/workflows/reusable-codex-run.yml');
+});
+
+test('getAgentModel returns model for claude', () => {
+  const model = getAgentModel('claude', { registryPath: REGISTRY_PATH });
+  assert.equal(model, 'claude-opus-4-7');
+});
+
+test('getAgentModel returns empty string when no model configured', () => {
+  const model = getAgentModel('codex', { registryPath: REGISTRY_PATH });
+  assert.equal(model, '');
 });
 
 test('getAgentEntries returns key/config pairs for each agent', () => {

--- a/.github/scripts/agent_registry.js
+++ b/.github/scripts/agent_registry.js
@@ -238,6 +238,11 @@ function getRunnerWorkflow(agentKey, { registryPath } = {}) {
   return workflow;
 }
 
+function getAgentModel(agentKey, { registryPath } = {}) {
+  const config = getAgentConfig(agentKey, { registryPath });
+  return String(config.model || '').trim();
+}
+
 /**
  * Return all automation logins across all agents in the registry.
  * Useful for detecting bot-authored comments/commits.
@@ -323,6 +328,7 @@ module.exports = {
   getAllAutomationLogins,
   getAgentConfig,
   getAgentEntries,
+  getAgentModel,
   getAgentPreflightConfigs,
   getKeepaliveMarkerPrefix,
   getReadinessCandidates,

--- a/.github/workflows/reusable-claude-run.yml
+++ b/.github/workflows/reusable-claude-run.yml
@@ -780,6 +780,32 @@ jobs:
           echo "Installed Claude CLI: $(command -v claude)"
           claude --version || true
 
+      - name: Resolve model from agent registry
+        id: resolve_model
+        shell: bash
+        run: |
+          registry=".github/agents/registry.yml"
+          if [ ! -f "$registry" ]; then
+            wl=".workflows-lib/.github/agents/registry.yml"
+            if [ -f "$wl" ]; then registry="$wl"; fi
+          fi
+          model=""
+          if [ -f "$registry" ]; then
+            model=$(node -e "
+              try {
+                const r = require('./.github/scripts/agent_registry.js');
+                const m = r.getAgentModel('claude');
+                if (m) process.stdout.write(m);
+              } catch (_) {}
+            " 2>/dev/null || true)
+          fi
+          if [ -n "$model" ]; then
+            echo "Resolved model from registry: $model"
+          else
+            echo "No model configured in registry; using CLI default"
+          fi
+          echo "model=$model" >> "$GITHUB_OUTPUT"
+
       - name: Run Claude
         id: run_claude
         if: always()
@@ -792,6 +818,7 @@ jobs:
           SKIP_PERMISSIONS: ${{ inputs.skip_permissions }}
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN || '' }}
           PR_REF: ${{ inputs.pr_ref }}
+          REGISTRY_MODEL: ${{ steps.resolve_model.outputs.model }}
         run: |
           set -euo pipefail
 
@@ -875,6 +902,12 @@ jobs:
             SESSION_LOG="claude-session.log"
           fi
 
+          model_flag=()
+          if [ -n "${REGISTRY_MODEL:-}" ]; then
+            model_flag=("--model" "$REGISTRY_MODEL")
+            echo "Using registry model: $REGISTRY_MODEL"
+          fi
+
           echo "Running Claude Code in agentic mode..."
           echo "Prompt file: $PROMPT_FILE"
           echo "Output file: $output_file"
@@ -887,6 +920,7 @@ jobs:
           # even if the run fails.
           set +e
           claude -p "$prompt_content" \
+            "${model_flag[@]}" \
             "${perm_flag[@]}" \
             "${extra_args[@]}" \
             2>&1 | tee "$SESSION_LOG" > "$output_file"

--- a/templates/consumer-repo/.github/agents/registry.yml
+++ b/templates/consumer-repo/.github/agents/registry.yml
@@ -27,6 +27,8 @@ agents:
       verifier_checkbox: true
 
   claude:
+    display_name: Claude
+    model: claude-opus-4-7
     runner_workflow: .github/workflows/reusable-claude-run.yml
     required_secrets:
       - CLAUDE_CODE_OAUTH_TOKEN  # preferred: long-lived token from `claude setup-token`

--- a/templates/consumer-repo/.github/scripts/agent_registry.js
+++ b/templates/consumer-repo/.github/scripts/agent_registry.js
@@ -238,6 +238,11 @@ function getRunnerWorkflow(agentKey, { registryPath } = {}) {
   return workflow;
 }
 
+function getAgentModel(agentKey, { registryPath } = {}) {
+  const config = getAgentConfig(agentKey, { registryPath });
+  return String(config.model || '').trim();
+}
+
 /**
  * Return all automation logins across all agents in the registry.
  * Useful for detecting bot-authored comments/commits.
@@ -323,6 +328,7 @@ module.exports = {
   getAllAutomationLogins,
   getAgentConfig,
   getAgentEntries,
+  getAgentModel,
   getAgentPreflightConfigs,
   getKeepaliveMarkerPrefix,
   getReadinessCandidates,


### PR DESCRIPTION
- Add `model: claude-opus-4-7` to Claude agent config in registry.yml
- Add `getAgentModel()` helper to agent_registry.js
- Wire reusable-claude-run.yml to read model from registry and pass --model flag to Claude CLI automatically
- No caller changes needed — the runner auto-detects from the registry

To change the Claude model, update `model:` in registry.yml.

https://claude.ai/code/session_01FC8XoyssN5v6hQCTtcjoB5