### PR TITLE
feat: upgrade Anthropic verification model from Sonnet 4.5 to Opus 4.7

### DIFF
--- a/templates/consumer-repo/tools/langchain_client.py
+++ b/templates/consumer-repo/tools/langchain_client.py
@@ -97,7 +97,7 @@ def _default_slots() -> list[SlotDefinition]:
     return [
         SlotDefinition(name="slot1", provider=PROVIDER_OPENAI, model="gpt-5.2"),
         SlotDefinition(
-            name="slot2", provider=PROVIDER_ANTHROPIC, model="claude-sonnet-4-5-20250929"
+            name="slot2", provider=PROVIDER_ANTHROPIC, model="claude-opus-4-7"
         ),
         SlotDefinition(name="slot3", provider=PROVIDER_GITHUB, model="gpt-4.1"),
     ]

--- a/templates/consumer-repo/tools/llm_provider.py
+++ b/templates/consumer-repo/tools/llm_provider.py
@@ -644,7 +644,7 @@ class AnthropicProvider(LLMProvider):
             return None
 
         return ChatAnthropic(
-            model="claude-sonnet-4-5-20250929",
+            model="claude-opus-4-7",
             anthropic_api_key=os.environ.get(ANTHROPIC_API_KEY_ENV),
             temperature=0.1,
         )
@@ -689,7 +689,7 @@ class AnthropicProvider(LLMProvider):
                 confidence=result.confidence,
                 reasoning=result.reasoning,
                 provider_used=self.name,
-                model_name="claude-sonnet-4-5-20250929",
+                model_name="claude-opus-4-7",
                 raw_confidence=result.raw_confidence,
                 confidence_adjusted=result.confidence_adjusted,
                 quality_warnings=result.quality_warnings,
@@ -940,7 +940,7 @@ def get_llm_provider(force_provider: str | None = None) -> LLMProvider:
             Options: "github-models", "openai", "anthropic", "regex-fallback"
 
     Returns a FallbackChainProvider that tries:
-    1. Anthropic claude-sonnet-4-5 (if CLAUDE_API_KEY set) - Best reasoning
+    1. Anthropic claude-opus-4-7 (if CLAUDE_API_KEY set) - Best reasoning
     2. OpenAI gpt-5.1-codex (if OPENAI_API_KEY set) - Purpose-built for code analysis
     3. GitHub Models gpt-4.1 (if GITHUB_TOKEN set) - Always available, reliable
     4. Regex fallback (always available) - 30% confidence baseline
@@ -968,7 +968,7 @@ def get_llm_provider(force_provider: str | None = None) -> LLMProvider:
         return provider
 
     providers = [
-        AnthropicProvider(),  # Primary: claude-sonnet-4-5 for best reasoning
+        AnthropicProvider(),  # Primary: claude-opus-4-7 for best reasoning
         OpenAIProvider(),  # Secondary: gpt-5.1-codex for code-optimized analysis
         GitHubModelsProvider(),  # Tertiary: gpt-4.1 via GITHUB_TOKEN (always available)
         RegexFallbackProvider(),  # Last resort: 30% confidence pattern matching

--- a/tools/langchain_client.py
+++ b/tools/langchain_client.py
@@ -97,7 +97,7 @@ def _default_slots() -> list[SlotDefinition]:
     return [
         SlotDefinition(name="slot1", provider=PROVIDER_OPENAI, model="gpt-5.2"),
         SlotDefinition(
-            name="slot2", provider=PROVIDER_ANTHROPIC, model="claude-sonnet-4-5-20250929"
+            name="slot2", provider=PROVIDER_ANTHROPIC, model="claude-opus-4-7"
         ),
         SlotDefinition(name="slot3", provider=PROVIDER_GITHUB, model="gpt-4.1"),
     ]

--- a/tools/llm_provider.py
+++ b/tools/llm_provider.py
@@ -656,7 +656,7 @@ class AnthropicProvider(LLMProvider):
             return None
 
         return ChatAnthropic(
-            model="claude-sonnet-4-5-20250929",
+            model="claude-opus-4-7",
             anthropic_api_key=os.environ.get(ANTHROPIC_API_KEY_ENV),
             temperature=0.1,
         )
@@ -701,7 +701,7 @@ class AnthropicProvider(LLMProvider):
                 confidence=result.confidence,
                 reasoning=result.reasoning,
                 provider_used=self.name,
-                model_name="claude-sonnet-4-5-20250929",
+                model_name="claude-opus-4-7",
                 raw_confidence=result.raw_confidence,
                 confidence_adjusted=result.confidence_adjusted,
                 quality_warnings=result.quality_warnings,
@@ -952,7 +952,7 @@ def get_llm_provider(force_provider: str | None = None) -> LLMProvider:
             Options: "github-models", "openai", "anthropic", "regex-fallback"
 
     Returns a FallbackChainProvider that tries:
-    1. Anthropic claude-sonnet-4-5 (if CLAUDE_API_KEY set) - Best reasoning
+    1. Anthropic claude-opus-4-7 (if CLAUDE_API_KEY set) - Best reasoning
     2. OpenAI gpt-5.1-codex (if OPENAI_API_KEY set) - Purpose-built for code analysis
     3. GitHub Models gpt-4.1 (if GITHUB_TOKEN set) - Always available, reliable
     4. Regex fallback (always available) - 30% confidence baseline
@@ -980,7 +980,7 @@ def get_llm_provider(force_provider: str | None = None) -> LLMProvider:
         return provider
 
     providers = [
-        AnthropicProvider(),  # Primary: claude-sonnet-4-5 for best reasoning
+        AnthropicProvider(),  # Primary: claude-opus-4-7 for best reasoning
         OpenAIProvider(),  # Secondary: gpt-5.1-codex for code-optimized analysis
         GitHubModelsProvider(),  # Tertiary: gpt-4.1 via GITHUB_TOKEN (always available)
         RegexFallbackProvider(),  # Last resort: 30% confidence pattern matching


### PR DESCRIPTION
The verify:compare workflow and LLM analysis used claude-sonnet-4-5 for the Anthropic provider. Switch to claude-opus-4-7 for better reasoning and task evaluation quality.

Updated in llm_provider.py (ChatAnthropic model + model_name) and langchain_client.py (default slot2 definition).

https://claude.ai/code/session_01FC8XoyssN5v6hQCTtcjoB5