### PR TITLE
fix: switch slot config and LANGCHAIN_MODEL to claude-opus-4-7

### DIFF
--- a/.github/workflows/agents-auto-pilot.yml
+++ b/.github/workflows/agents-auto-pilot.yml
@@ -912,7 +912,7 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           CLAUDE_API_KEY: ${{ secrets.CLAUDE_API_KEY }}
           LANGCHAIN_PROVIDER: anthropic
-          LANGCHAIN_MODEL: claude-sonnet-4-5-20250929
+          LANGCHAIN_MODEL: claude-opus-4-7
           PYTHONPATH: ${{ github.workspace }}
         run: |
 
@@ -1266,7 +1266,7 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           CLAUDE_API_KEY: ${{ secrets.CLAUDE_API_KEY }}
           LANGCHAIN_PROVIDER: anthropic
-          LANGCHAIN_MODEL: claude-sonnet-4-5-20250929
+          LANGCHAIN_MODEL: claude-opus-4-7
           PYTHONPATH: ${{ github.workspace }}
         run: |
 

--- a/.github/workflows/agents-issue-optimizer.yml
+++ b/.github/workflows/agents-issue-optimizer.yml
@@ -243,7 +243,7 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           CLAUDE_API_KEY: ${{ secrets.CLAUDE_API_KEY }}
           LANGCHAIN_PROVIDER: anthropic
-          LANGCHAIN_MODEL: claude-sonnet-4-5-20250929
+          LANGCHAIN_MODEL: claude-opus-4-7
           PYTHONPATH: ${{ github.workspace }}
         run: |
           echo "Running analysis on issue #${ISSUE_NUMBER}"
@@ -440,7 +440,7 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           CLAUDE_API_KEY: ${{ secrets.CLAUDE_API_KEY }}
           LANGCHAIN_PROVIDER: anthropic
-          LANGCHAIN_MODEL: claude-sonnet-4-5-20250929
+          LANGCHAIN_MODEL: claude-opus-4-7
           PYTHONPATH: ${{ github.workspace }}
         run: |
           echo "Extracting suggestions from comments on issue #${ISSUE_NUMBER}"

--- a/config/llm_slots.json
+++ b/config/llm_slots.json
@@ -8,7 +8,7 @@
     {
       "name": "slot2",
       "provider": "anthropic",
-      "model": "claude-sonnet-4-5-20250929"
+      "model": "claude-opus-4-7"
     },
     {
       "name": "slot3",

--- a/templates/consumer-repo/.github/workflows/agents-auto-pilot.yml
+++ b/templates/consumer-repo/.github/workflows/agents-auto-pilot.yml
@@ -912,7 +912,7 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           CLAUDE_API_KEY: ${{ secrets.CLAUDE_API_KEY }}
           LANGCHAIN_PROVIDER: anthropic
-          LANGCHAIN_MODEL: claude-sonnet-4-5-20250929
+          LANGCHAIN_MODEL: claude-opus-4-7
           PYTHONPATH: ${{ github.workspace }}
         run: |
 
@@ -1266,7 +1266,7 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           CLAUDE_API_KEY: ${{ secrets.CLAUDE_API_KEY }}
           LANGCHAIN_PROVIDER: anthropic
-          LANGCHAIN_MODEL: claude-sonnet-4-5-20250929
+          LANGCHAIN_MODEL: claude-opus-4-7
           PYTHONPATH: ${{ github.workspace }}
         run: |
 

--- a/templates/consumer-repo/.github/workflows/agents-issue-optimizer.yml
+++ b/templates/consumer-repo/.github/workflows/agents-issue-optimizer.yml
@@ -251,7 +251,7 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           CLAUDE_API_KEY: ${{ secrets.CLAUDE_API_KEY }}
           LANGCHAIN_PROVIDER: anthropic
-          LANGCHAIN_MODEL: claude-sonnet-4-5-20250929
+          LANGCHAIN_MODEL: claude-opus-4-7
           PYTHONPATH: ${{ github.workspace }}/workflows-scripts
         run: |
           echo "Running analysis on issue #${ISSUE_NUMBER}"
@@ -396,7 +396,7 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           CLAUDE_API_KEY: ${{ secrets.CLAUDE_API_KEY }}
           LANGCHAIN_PROVIDER: anthropic
-          LANGCHAIN_MODEL: claude-sonnet-4-5-20250929
+          LANGCHAIN_MODEL: claude-opus-4-7
           PYTHONPATH: ${{ github.workspace }}/workflows-scripts
         run: |
           echo "Extracting suggestions from comments on issue #${ISSUE_NUMBER}"

--- a/templates/consumer-repo/config/llm_slots.json
+++ b/templates/consumer-repo/config/llm_slots.json
@@ -8,7 +8,7 @@
     {
       "name": "slot2",
       "provider": "anthropic",
-      "model": "claude-sonnet-4-5-20250929"
+      "model": "claude-opus-4-7"
     },
     {
       "name": "slot3",


### PR DESCRIPTION
The previous commit updated the Python defaults but missed the actual runtime config. The verify:compare flow reads from config/llm_slots.json (via langchain_client._load_slot_config), and the optimizer/auto-pilot workflows pass LANGCHAIN_MODEL env var that overrides the slot.

Both now point to claude-opus-4-7.

https://claude.ai/code/session_01FC8XoyssN5v6hQCTtcjoB5