### PR TITLE
feat: add OPENAI_API_KEY fallback for Codex auth and fix verify step …

### DIFF
--- a/.github/agents/registry.yml
+++ b/.github/agents/registry.yml
@@ -10,6 +10,8 @@ agents:
     runner_workflow: .github/workflows/reusable-codex-run.yml
     required_secrets:
       - CODEX_AUTH_JSON
+      - OPENAI_API_KEY
+    required_secrets_mode: any
     branch_prefix: codex/issue-
     ui_mentions_allowed: false
     automation_logins:

--- a/.github/scripts/keepalive_loop.js
+++ b/.github/scripts/keepalive_loop.js
@@ -2339,6 +2339,7 @@ async function evaluateKeepaliveLoop({ github: rawGithub, context, core, payload
         // Build secrets availability from env vars set by the workflow
         const secrets = {};
         if (process.env.HAS_CODEX_AUTH === 'true') secrets.CODEX_AUTH_JSON = true;
+        if (process.env.HAS_OPENAI_KEY === 'true') secrets.OPENAI_API_KEY = true;
         if (process.env.HAS_CLAUDE_AUTH === 'true') secrets.CLAUDE_AUTH_JSON = true;
         if (process.env.HAS_CLAUDE_OAUTH === 'true') secrets.CLAUDE_CODE_OAUTH_TOKEN = true;
         const decision = decideNextAgent({

--- a/.github/workflows/agents-auto-pilot.yml
+++ b/.github/workflows/agents-auto-pilot.yml
@@ -2059,9 +2059,7 @@ jobs:
               env: process.env,
               task: 'auto-pilot-verify',
               capabilities: ['issues:write', 'pulls:read']
-              }));
-              const prefix = `Dispatched belt dispatcher (agent: ${agentKey}) for issue`;
-              core.info(`${prefix} #${issueNumber}`);
+            });
 
             // Find the merged PR for this issue
             // Look for PRs with the meta marker or explicit closing reference

--- a/.github/workflows/agents-keepalive-loop.yml
+++ b/.github/workflows/agents-keepalive-loop.yml
@@ -235,6 +235,7 @@ jobs:
                 github.event.inputs.force_retry ||
                 'false' }}
           HAS_CODEX_AUTH: ${{ secrets.CODEX_AUTH_JSON != '' }}
+          HAS_OPENAI_KEY: ${{ secrets.OPENAI_API_KEY != '' }}
           HAS_CLAUDE_AUTH: ${{ secrets.CLAUDE_AUTH_JSON != '' }}
           HAS_CLAUDE_OAUTH: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN != '' }}
         with:
@@ -410,6 +411,7 @@ jobs:
         id: check
         env:
           HAS_CODEX_AUTH: ${{ secrets.CODEX_AUTH_JSON != '' }}
+          HAS_OPENAI_KEY: ${{ secrets.OPENAI_API_KEY != '' }}
           HAS_CLAUDE_AUTH: ${{ secrets.CLAUDE_AUTH_JSON != '' }}
           HAS_CLAUDE_OAUTH: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN != '' }}
           AGENT_TYPE: ${{ needs.evaluate.outputs.agent_type || 'codex' }}
@@ -422,6 +424,7 @@ jobs:
         run: |
           echo "Requested agent: $AGENT_TYPE"
           echo "CODEX_AUTH_JSON present: $HAS_CODEX_AUTH"
+          echo "OPENAI_API_KEY present: $HAS_OPENAI_KEY"
           echo "CLAUDE_AUTH_JSON present: $HAS_CLAUDE_AUTH"
           echo "CLAUDE_CODE_OAUTH_TOKEN present: $HAS_CLAUDE_OAUTH"
           echo "KEEPALIVE_APP or WORKFLOWS_APP present: $HAS_APP_ID"
@@ -434,12 +437,12 @@ jobs:
               fi
               ;;
             codex)
-              if [ "$HAS_CODEX_AUTH" = "true" ]; then
+              if [ "$HAS_CODEX_AUTH" = "true" ] || [ "$HAS_OPENAI_KEY" = "true" ]; then
                 agent_auth_ok=true
               fi
               ;;
             *)
-              if [ "$HAS_CODEX_AUTH" = "true" ] || [ "$HAS_CLAUDE_AUTH" = "true" ] || [ "$HAS_CLAUDE_OAUTH" = "true" ]; then
+              if [ "$HAS_CODEX_AUTH" = "true" ] || [ "$HAS_OPENAI_KEY" = "true" ] || [ "$HAS_CLAUDE_AUTH" = "true" ] || [ "$HAS_CLAUDE_OAUTH" = "true" ]; then
                 agent_auth_ok=true
               fi
               ;;

--- a/.github/workflows/reusable-codex-run.yml
+++ b/.github/workflows/reusable-codex-run.yml
@@ -658,21 +658,21 @@ jobs:
         id: codex_auth
         env:
           CODEX_AUTH_JSON: ${{ secrets.CODEX_AUTH_JSON }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
           set -euo pipefail
-          if [ -z "$CODEX_AUTH_JSON" ]; then
-            echo "::error::CODEX_AUTH_JSON secret is not set or empty."
-            echo "::error::Please add it to repository secrets."
-            echo "Go to: https://github.com/${{ github.repository }}/settings/secrets/actions"
-            exit 1
-          fi
-          mkdir -p ~/.codex
-          echo "$CODEX_AUTH_JSON" > ~/.codex/auth.json
-          chmod 600 ~/.codex/auth.json
-          echo "✅ Codex auth configured from CODEX_AUTH_JSON secret"
 
-          # Check token expiration
-          python3 << 'PYEOF'
+          auth_method=""
+
+          if [ -n "${CODEX_AUTH_JSON:-}" ]; then
+            mkdir -p ~/.codex
+            echo "$CODEX_AUTH_JSON" > ~/.codex/auth.json
+            chmod 600 ~/.codex/auth.json
+            echo "✅ Codex auth configured from CODEX_AUTH_JSON secret"
+
+            # Check token expiration — fall back to OPENAI_API_KEY if expired
+            auth_method="codex_auth_json"
+            python3 << 'PYEOF' || auth_method="expired"
           import json, base64, datetime, sys, os
 
           auth_path = os.path.expanduser("~/.codex/auth.json")
@@ -703,21 +703,18 @@ jobs:
               print(f"Token expires: {exp_time.isoformat()}")
               print(f"Days until expiration: {days_left}")
 
-              # Output for GitHub Actions
               with open(os.environ.get("GITHUB_OUTPUT", "/dev/null"), "a") as gh:
                   gh.write(f"token_expires={exp_time.isoformat()}\n")
                   gh.write(f"days_until_expiry={days_left}\n")
 
               if days_left < 0:
                   print("::error::CODEX_AUTH_JSON has expired!")
-                  print("::error::Run 'codex login --device-auth' and update the secret.")
-                  print("::error::See docs/ci/CHATGPT_SUBSCRIPTION_CI.md for instructions.")
+                  print("::warning::Will fall back to OPENAI_API_KEY if available.")
                   sys.exit(1)
               elif days_left < 2:
                   print(
                     f"::warning::CODEX_AUTH_JSON expires in {hours_left:.0f} hours!"
                   )
-                  print("::warning::Consider refreshing soon.")
                   print("::warning::Run 'codex login --device-auth' and update the secret.")
               elif days_left < 5:
                   print(f"::notice::CODEX_AUTH_JSON expires in {days_left} days.")
@@ -725,6 +722,22 @@ jobs:
           except Exception as e:
               print(f"::warning::Could not check token expiration: {e}")
           PYEOF
+          fi
+
+          # Fall back to OPENAI_API_KEY when CODEX_AUTH_JSON is missing or expired
+          if [ "$auth_method" != "codex_auth_json" ] && [ -n "${OPENAI_API_KEY:-}" ]; then
+            auth_method="openai_api_key"
+            echo "✅ Using OPENAI_API_KEY for Codex authentication"
+          fi
+
+          if [ -z "$auth_method" ] || { [ "$auth_method" = "expired" ] && [ -z "${OPENAI_API_KEY:-}" ]; }; then
+            echo "::error::No valid Codex credentials found."
+            echo "::error::Set CODEX_AUTH_JSON (codex login --device-auth) or OPENAI_API_KEY."
+            echo "Go to: https://github.com/${{ github.repository }}/settings/secrets/actions"
+            exit 1
+          fi
+
+          echo "auth_method=${auth_method}" >> "$GITHUB_OUTPUT"
 
       # Clean up workflow-generated files that would confuse Codex about git state.
       # The .workflows-lib directory is a separate checkout (NOT a submodule) for scripts
@@ -860,13 +873,19 @@ jobs:
         id: run_codex
         env:
           CODEX_HOME: ${{ runner.temp }}/.codex
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          CODEX_AUTH_METHOD: ${{ steps.codex_auth.outputs.auth_method }}
         run: |
           set -euo pipefail
 
-          # Copy auth to CODEX_HOME
+          # Copy auth to CODEX_HOME (skip if using API key fallback)
           mkdir -p "$CODEX_HOME"
-          cp ~/.codex/auth.json "$CODEX_HOME/auth.json"
-          chmod 600 "$CODEX_HOME/auth.json"
+          if [ "$CODEX_AUTH_METHOD" != "openai_api_key" ] && [ -f ~/.codex/auth.json ]; then
+            cp ~/.codex/auth.json "$CODEX_HOME/auth.json"
+            chmod 600 "$CODEX_HOME/auth.json"
+          elif [ "$CODEX_AUTH_METHOD" = "openai_api_key" ]; then
+            echo "Using OPENAI_API_KEY (auth.json skipped)"
+          fi
 
           # Build codex exec command
           PROMPT_FILE="${{ steps.prompt.outputs.file }}"

--- a/templates/consumer-repo/.github/agents/registry.yml
+++ b/templates/consumer-repo/.github/agents/registry.yml
@@ -10,6 +10,8 @@ agents:
     runner_workflow: .github/workflows/reusable-codex-run.yml
     required_secrets:
       - CODEX_AUTH_JSON
+      - OPENAI_API_KEY
+    required_secrets_mode: any
     branch_prefix: codex/issue-
     ui_mentions_allowed: false
     automation_logins:

--- a/templates/consumer-repo/.github/scripts/keepalive_loop.js
+++ b/templates/consumer-repo/.github/scripts/keepalive_loop.js
@@ -2339,6 +2339,7 @@ async function evaluateKeepaliveLoop({ github: rawGithub, context, core, payload
         // Build secrets availability from env vars set by the workflow
         const secrets = {};
         if (process.env.HAS_CODEX_AUTH === 'true') secrets.CODEX_AUTH_JSON = true;
+        if (process.env.HAS_OPENAI_KEY === 'true') secrets.OPENAI_API_KEY = true;
         if (process.env.HAS_CLAUDE_AUTH === 'true') secrets.CLAUDE_AUTH_JSON = true;
         if (process.env.HAS_CLAUDE_OAUTH === 'true') secrets.CLAUDE_CODE_OAUTH_TOKEN = true;
         const decision = decideNextAgent({

--- a/templates/consumer-repo/.github/workflows/agents-81-gate-followups.yml
+++ b/templates/consumer-repo/.github/workflows/agents-81-gate-followups.yml
@@ -210,6 +210,7 @@ jobs:
         id: check
         env:
           HAS_CODEX_AUTH: ${{ secrets.CODEX_AUTH_JSON != '' }}
+          HAS_OPENAI_KEY: ${{ secrets.OPENAI_API_KEY != '' }}
           HAS_CLAUDE_AUTH: ${{ secrets.CLAUDE_AUTH_JSON != '' }}
           HAS_CLAUDE_OAUTH: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN != '' }}
           HAS_GEMINI_AUTH: ${{ secrets.GEMINI_API_KEY != '' }}
@@ -222,6 +223,7 @@ jobs:
           AGENT_TYPE: ${{ needs.evaluate.outputs.agent_type }}
         run: |
           echo "CODEX_AUTH_JSON present: $HAS_CODEX_AUTH"
+          echo "OPENAI_API_KEY present: $HAS_OPENAI_KEY"
           echo "CLAUDE_AUTH_JSON present: $HAS_CLAUDE_AUTH"
           echo "CLAUDE_CODE_OAUTH_TOKEN present: $HAS_CLAUDE_OAUTH"
           echo "GEMINI_API_KEY present: $HAS_GEMINI_AUTH"
@@ -233,7 +235,7 @@ jobs:
           agent_auth_ok=false
           case "$AGENT_TYPE" in
             codex)
-              if [ "$HAS_CODEX_AUTH" = "true" ] || [ "$HAS_APP_ID" = "true" ]; then
+              if [ "$HAS_CODEX_AUTH" = "true" ] || [ "$HAS_OPENAI_KEY" = "true" ] || [ "$HAS_APP_ID" = "true" ]; then
                 agent_auth_ok=true
               fi
               ;;
@@ -249,7 +251,7 @@ jobs:
               ;;
             *)
               # Unknown agent - fall back to any auth available
-              if [ "$HAS_CODEX_AUTH" = "true" ] || [ "$HAS_CLAUDE_AUTH" = "true" ] || [ "$HAS_CLAUDE_OAUTH" = "true" ] || [ "$HAS_GEMINI_AUTH" = "true" ] || [ "$HAS_APP_ID" = "true" ]; then
+              if [ "$HAS_CODEX_AUTH" = "true" ] || [ "$HAS_OPENAI_KEY" = "true" ] || [ "$HAS_CLAUDE_AUTH" = "true" ] || [ "$HAS_CLAUDE_OAUTH" = "true" ] || [ "$HAS_GEMINI_AUTH" = "true" ] || [ "$HAS_APP_ID" = "true" ]; then
                 agent_auth_ok=true
               fi
               ;;
@@ -258,7 +260,7 @@ jobs:
           if [ "$agent_auth_ok" = "true" ]; then
             echo "secrets_ok=true" >> "$GITHUB_OUTPUT"
           else
-            echo "::error::No auth found for agent '$AGENT_TYPE'. Set the appropriate secret (GEMINI_API_KEY for gemini, CLAUDE_CODE_OAUTH_TOKEN for claude, CODEX_AUTH_JSON for codex)."
+            echo "::error::No auth found for agent '$AGENT_TYPE'. Set CODEX_AUTH_JSON, OPENAI_API_KEY, CLAUDE_CODE_OAUTH_TOKEN, or GEMINI_API_KEY."
             echo "secrets_ok=false" >> "$GITHUB_OUTPUT"
             exit 1
           fi
@@ -329,6 +331,7 @@ jobs:
     uses: iamkayleb/Workflows/.github/workflows/reusable-codex-run.yml@main
     secrets:
       CODEX_AUTH_JSON: ${{ secrets.CODEX_AUTH_JSON }}
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       # Use dedicated KEEPALIVE_APP for isolated rate limit pool (5000/hr)
       # Falls back to WORKFLOWS_APP if KEEPALIVE_APP not configured
       WORKFLOWS_APP_ID: >-
@@ -1072,6 +1075,7 @@ jobs:
       appendix: ${{ needs.prepare.outputs.appendix }}
     secrets:
       CODEX_AUTH_JSON: ${{ secrets.CODEX_AUTH_JSON }}
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       WORKFLOWS_APP_ID: ${{ secrets.WORKFLOWS_APP_ID }}
       WORKFLOWS_APP_PRIVATE_KEY: ${{ secrets.WORKFLOWS_APP_PRIVATE_KEY }}
 

--- a/templates/consumer-repo/.github/workflows/agents-auto-pilot.yml
+++ b/templates/consumer-repo/.github/workflows/agents-auto-pilot.yml
@@ -2029,9 +2029,7 @@ jobs:
               env: process.env,
               task: 'auto-pilot-verify',
               capabilities: ['issues:write', 'pulls:read']
-              }));
-              const prefix = `Dispatched belt dispatcher (agent: ${agentKey}) for issue`;
-              core.info(`${prefix} #${issueNumber}`);
+            });
 
             // Find the merged PR for this issue
             // Look for PRs with the meta marker or explicit closing reference

--- a/templates/consumer-repo/.github/workflows/agents-autofix-loop.yml
+++ b/templates/consumer-repo/.github/workflows/agents-autofix-loop.yml
@@ -605,6 +605,7 @@ jobs:
         }}
     secrets:
       CODEX_AUTH_JSON: ${{ secrets.CODEX_AUTH_JSON }}
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       WORKFLOWS_APP_ID: ${{ secrets.WORKFLOWS_APP_ID }}
       WORKFLOWS_APP_PRIVATE_KEY: ${{ secrets.WORKFLOWS_APP_PRIVATE_KEY }}
 

--- a/templates/consumer-repo/.github/workflows/agents-keepalive-loop.yml
+++ b/templates/consumer-repo/.github/workflows/agents-keepalive-loop.yml
@@ -235,6 +235,7 @@ jobs:
                 github.event.inputs.force_retry ||
                 'false' }}
           HAS_CODEX_AUTH: ${{ secrets.CODEX_AUTH_JSON != '' }}
+          HAS_OPENAI_KEY: ${{ secrets.OPENAI_API_KEY != '' }}
           HAS_CLAUDE_AUTH: ${{ secrets.CLAUDE_AUTH_JSON != '' }}
           HAS_CLAUDE_OAUTH: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN != '' }}
         with:
@@ -410,6 +411,7 @@ jobs:
         id: check
         env:
           HAS_CODEX_AUTH: ${{ secrets.CODEX_AUTH_JSON != '' }}
+          HAS_OPENAI_KEY: ${{ secrets.OPENAI_API_KEY != '' }}
           HAS_CLAUDE_AUTH: ${{ secrets.CLAUDE_AUTH_JSON != '' }}
           HAS_CLAUDE_OAUTH: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN != '' }}
           HAS_GEMINI_AUTH: ${{ secrets.GEMINI_API_KEY != '' }}
@@ -423,6 +425,7 @@ jobs:
         run: |
           echo "Requested agent: $AGENT_TYPE"
           echo "CODEX_AUTH_JSON present: $HAS_CODEX_AUTH"
+          echo "OPENAI_API_KEY present: $HAS_OPENAI_KEY"
           echo "CLAUDE_AUTH_JSON present: $HAS_CLAUDE_AUTH"
           echo "CLAUDE_CODE_OAUTH_TOKEN present: $HAS_CLAUDE_OAUTH"
           echo "GEMINI_API_KEY present: $HAS_GEMINI_AUTH"
@@ -436,7 +439,7 @@ jobs:
               fi
               ;;
             codex)
-              if [ "$HAS_CODEX_AUTH" = "true" ]; then
+              if [ "$HAS_CODEX_AUTH" = "true" ] || [ "$HAS_OPENAI_KEY" = "true" ]; then
                 agent_auth_ok=true
               fi
               ;;
@@ -446,7 +449,7 @@ jobs:
               fi
               ;;
             *)
-              if [ "$HAS_CODEX_AUTH" = "true" ] || [ "$HAS_CLAUDE_AUTH" = "true" ] || [ "$HAS_CLAUDE_OAUTH" = "true" ] || [ "$HAS_GEMINI_AUTH" = "true" ]; then
+              if [ "$HAS_CODEX_AUTH" = "true" ] || [ "$HAS_OPENAI_KEY" = "true" ] || [ "$HAS_CLAUDE_AUTH" = "true" ] || [ "$HAS_CLAUDE_OAUTH" = "true" ] || [ "$HAS_GEMINI_AUTH" = "true" ]; then
                 agent_auth_ok=true
               fi
               ;;


### PR DESCRIPTION
…syntax

The Codex runner now accepts OPENAI_API_KEY as a fallback when CODEX_AUTH_JSON is missing or expired. The Codex CLI natively supports this env var, so no CLI-side changes are needed.

Changes across 11 files (canonical + consumer templates):
- reusable-codex-run.yml: auth step tries CODEX_AUTH_JSON first, falls back to OPENAI_API_KEY; run step passes OPENAI_API_KEY to env
- agents-keepalive-loop.yml: add HAS_OPENAI_KEY to secret checks and codex case branch
- agents-81-gate-followups.yml: add HAS_OPENAI_KEY to secret checks and pass OPENAI_API_KEY to reusable workflow secrets
- agents-autofix-loop.yml: pass OPENAI_API_KEY to reusable workflow
- keepalive_loop.js: wire HAS_OPENAI_KEY into delegation secrets map
- registry.yml: codex agent now lists OPENAI_API_KEY with mode: any
- agents-auto-pilot.yml: fix syntax error in verify step (leftover })); and stale agentKey/issueNumber references from capability-check)

https://claude.ai/code/session_01FC8XoyssN5v6hQCTtcjoB5