### PR TITLE
fix: remove duplicate review_guard step in keepalive template

### DIFF
--- a/templates/consumer-repo/.github/workflows/agents-keepalive-loop.yml
+++ b/templates/consumer-repo/.github/workflows/agents-keepalive-loop.yml
@@ -821,12 +821,6 @@ jobs:
         run: |
           node .github/scripts/should-post-review.js review_result.json
 
-
-      - name: Evaluate whether to post review
-        id: review_guard
-        run: |
-          node .github/scripts/should-post-review.js review_result.json
-
       - name: Post review feedback to PR
         if: steps.review_guard.outputs.should_post_review == 'true'
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8


### PR DESCRIPTION
The 'Evaluate whether to post review' step (id: review_guard) was duplicated at lines 819-828, causing GitHub Actions to reject the workflow with "identifier 'review_guard' may not be used more than once." This completely prevented the keepalive loop from running.

https://claude.ai/code/session_01FC8XoyssN5v6hQCTtcjoB5