### PR TITLE
fix: make editable pip install non-fatal in all reusable agent runners

### DIFF
--- a/.github/workflows/reusable-claude-run.yml
+++ b/.github/workflows/reusable-claude-run.yml
@@ -407,7 +407,10 @@ jobs:
           fi
 
           if [ -f pyproject.toml ]; then
-            python -m pip install -e ".[dev]" || python -m pip install -e .
+            python -m pip install -e ".[dev]" || python -m pip install -e . || {
+              echo "::warning::Editable install failed — the repo may not have a valid Python package structure."
+              echo "::warning::Agent will continue without editable install."
+            }
           fi
 
       - name: Install Workflows repo LLM dependencies

--- a/.github/workflows/reusable-codex-run.yml
+++ b/.github/workflows/reusable-codex-run.yml
@@ -424,7 +424,10 @@ jobs:
           fi
 
           if [ -f pyproject.toml ]; then
-            python -m pip install -e ".[dev]" || python -m pip install -e .
+            python -m pip install -e ".[dev]" || python -m pip install -e . || {
+              echo "::warning::Editable install failed — the repo may not have a valid Python package structure."
+              echo "::warning::Codex will continue without editable install."
+            }
           fi
 
       - name: Install Workflows repo LLM dependencies

--- a/.github/workflows/reusable-gemini-run.yml
+++ b/.github/workflows/reusable-gemini-run.yml
@@ -401,7 +401,10 @@ jobs:
           fi
 
           if [ -f pyproject.toml ]; then
-            python -m pip install -e ".[dev]" || python -m pip install -e .
+            python -m pip install -e ".[dev]" || python -m pip install -e . || {
+              echo "::warning::Editable install failed — the repo may not have a valid Python package structure."
+              echo "::warning::Agent will continue without editable install."
+            }
           fi
 
       - name: Install Workflows repo LLM dependencies

--- a/templates/consumer-repo/pyproject.toml
+++ b/templates/consumer-repo/pyproject.toml
@@ -12,11 +12,14 @@ requires-python = ">=3.11"
 app = []
 dev = []
 
-[tool.setuptools.packages.find]
-where = ["src"]
-
-[tool.setuptools.package-dir]
-"" = "src"
+[tool.setuptools]
+# No importable packages by default. If this repo becomes a Python project
+# with a src/ layout, replace with:
+#   [tool.setuptools.packages.find]
+#   where = ["src"]
+#   [tool.setuptools.package-dir]
+#   "" = "src"
+packages = []
 
 [tool.black]
 line-length = 100


### PR DESCRIPTION
Consumer repos without a valid Python package structure (e.g., missing src/ directory) fail at pip install -e . when pyproject.toml exists but references a src layout. This blocks the entire agent run unnecessarily.

Also updates the consumer template pyproject.toml to use packages = [] instead of assuming a src/ layout that may not exist.

https://claude.ai/code/session_01FC8XoyssN5v6hQCTtcjoB5