### PR TITLE
fix: undefined agentType crash in keepalive summary job

### DIFF
--- a/.github/workflows/agents-keepalive-loop.yml
+++ b/.github/workflows/agents-keepalive-loop.yml
@@ -1107,7 +1107,7 @@ jobs:
               tasks_unchecked: Number('${{ needs.evaluate.outputs.tasks_unchecked }}') || 0,
               keepalive_enabled: '${{ needs.evaluate.outputs.keepalive_enabled }}',
               autofix_enabled: '${{ needs.evaluate.outputs.autofix_enabled }}',
-              agent_type: agentType,
+              agent_type: '${{ needs.evaluate.outputs.agent_type }}',
               trace: '${{ needs.evaluate.outputs.trace }}',
               // Agent run result - check which agent ran
               run_result: runResult,

--- a/templates/consumer-repo/.github/workflows/agents-keepalive-loop.yml
+++ b/templates/consumer-repo/.github/workflows/agents-keepalive-loop.yml
@@ -1168,7 +1168,7 @@ jobs:
               tasks_unchecked: Number('${{ needs.evaluate.outputs.tasks_unchecked }}') || 0,
               keepalive_enabled: '${{ needs.evaluate.outputs.keepalive_enabled }}',
               autofix_enabled: '${{ needs.evaluate.outputs.autofix_enabled }}',
-              agent_type: agentType,
+              agent_type: '${{ needs.evaluate.outputs.agent_type }}',
               trace: '${{ needs.evaluate.outputs.trace }}',
               // Agent run result - check which agent ran
               run_result: runResult,


### PR DESCRIPTION
The summary job's update-summary inline script referenced a bare `agentType` variable that was never declared in that script's scope (only a different job declares it). This threw
"ReferenceError: agentType is not defined" on every keepalive round, crashing the summary job before it could persist state.

Symptoms this caused on consumer repos:
- iteration counter frozen (never incremented/saved)
- Work Log table never written
- "agent actively working" status never updated to completion
- loop bookkeeping (rounds_without_task_completion, etc.) never advanced
- agent effectively stops after the first task

Fix: use the evaluate job's agent_type output like every neighboring field. Applied to both the canonical and consumer-template workflows.

https://claude.ai/code/session_01FC8XoyssN5v6hQCTtcjoB5