### PR TITLE
fix: pin a ChatGPT-supported Codex model (default gpt-5.1-codex)

### DIFF
--- a/.github/workflows/reusable-codex-run.yml
+++ b/.github/workflows/reusable-codex-run.yml
@@ -886,6 +886,11 @@ jobs:
           # the CODEX_AUTH_JSON subscription token, not the metered API key
           # (which is reserved for verify:compare).
           CODEX_AUTH_METHOD: ${{ steps.codex_auth.outputs.auth_method }}
+          # Model Codex runs. The CLI default (gpt-5.2-codex) is NOT available on
+          # ChatGPT-account auth, so we pin a supported codex model. Override per
+          # consumer with the CODEX_MODEL repo variable if your plan supports a
+          # different one (e.g. gpt-5-codex).
+          CODEX_MODEL: ${{ vars.CODEX_MODEL || 'gpt-5.1-codex' }}
         run: |
           set -euo pipefail
 
@@ -1062,6 +1067,13 @@ jobs:
             --sandbox "$SANDBOX"
             --output-last-message "$OUTPUT_FILE"
           )
+          # Pin the model when set (CLI default gpt-5.2-codex is rejected by
+          # ChatGPT-account auth). Allow EXTRA_ARGS to override by only adding
+          # --model if the caller didn't already pass one.
+          if [ -n "${CODEX_MODEL:-}" ] && ! printf '%s\n' "${EXTRA_ARGS[@]:-}" | grep -qx -- '--model'; then
+            cmd+=(--model "$CODEX_MODEL")
+            echo "Codex model: $CODEX_MODEL"
+          fi
           if [ "${#EXTRA_ARGS[@]}" -gt 0 ]; then
             cmd+=("${EXTRA_ARGS[@]}")
           fi

--- a/docs/keepalive/GoalsAndPlumbing.md
+++ b/docs/keepalive/GoalsAndPlumbing.md
@@ -139,7 +139,7 @@ The keepalive loop routes to different agent workflows based on the `agent:*` la
 
 | Label | Agent | Workflow |
 |-------|-------|----------|
-| `agent:codex` | Codex CLI (gpt-5.2-codex) | `reusable-codex-run.yml` |
+| `agent:codex` | Codex CLI (gpt-5.1-codex) | `reusable-codex-run.yml` |
 
 Only `agent:codex` is currently implemented in this repository. Other `agent:*` labels may be reserved for future expansion.
 

--- a/docs/keepalive/MULTI_AGENT_ROUTING.md
+++ b/docs/keepalive/MULTI_AGENT_ROUTING.md
@@ -13,7 +13,7 @@ The keepalive system routes work to different agents based on the `agent:*` labe
 
 | Label | Agent | Workflow |
 |-------|-------|----------|
-| `agent:codex` | Codex CLI (gpt-5.2-codex) | `reusable-codex-run.yml` |
+| `agent:codex` | Codex CLI (gpt-5.1-codex) | `reusable-codex-run.yml` |
 | `agent:claude` | Claude (future) | *(not implemented in this repo)* |
 | `agent:gemini` | Gemini (future) | *(not implemented in this repo)* |
 

--- a/docs/troubleshooting/MULTI_AGENT_TESTING_RETROSPECTIVE.md
+++ b/docs/troubleshooting/MULTI_AGENT_TESTING_RETROSPECTIVE.md
@@ -259,6 +259,33 @@ is exactly why `maint-53` *notifies* rather than auto-bumps. Sandbox/runtime
 regressions in a coding-agent CLI are invisible until the agent tries to run a
 command.
 
+### Issue 18: Codex CLI default model unsupported on ChatGPT-account auth
+
+**Symptom:** With the sandbox fixed (0.101.0), Codex authenticated
+(`auth: codex_auth_json`), ran ~6s, exited 1, and wrote an **empty**
+`codex-output`. The session JSONL showed the real error:
+
+```
+error: "The 'gpt-5.2-codex' model is not supported when using Codex with a ChatGPT account."
+turn.failed → no last agent message → empty content written
+```
+
+**Root cause:** The runner never passed `--model`, so Codex used the CLI's
+built-in default (`gpt-5.2-codex`). That model is not available to
+**ChatGPT-subscription** auth (`CODEX_AUTH_JSON`), so the very first turn failed
+before any work. (Model availability for ChatGPT accounts changes over time —
+this likely worked on earlier runs when the default was a supported model.)
+
+**Fix (this change):** Pin the model explicitly in `reusable-codex-run.yml`
+(`--model "$CODEX_MODEL"`), defaulting to `gpt-5.1-codex` and overridable per
+consumer via the `CODEX_MODEL` repo variable (e.g. `gpt-5-codex`). The flag is
+only added if the caller didn't already pass `--model` via `codex_args`.
+
+**Lesson:** Two different "Codex versions" matter and fail independently: the
+**CLI version** (npm `@openai/codex`) and the **model** it requests. ChatGPT
+auth and API auth support different model sets — pin a model the auth method
+actually allows, and make it configurable.
+
 ---
 
 ## Phase 4 — Keepalive loop state (the big one)

--- a/templates/consumer-repo/README.md
+++ b/templates/consumer-repo/README.md
@@ -196,7 +196,7 @@ The keepalive system uses PR labels for routing and control:
 ### Agent Selection
 | Label | Agent | Workflow |
 |-------|-------|----------|
-| `agent:codex` | Codex CLI (gpt-5.2-codex) | `reusable-codex-run.yml` |
+| `agent:codex` | Codex CLI (gpt-5.1-codex) | `reusable-codex-run.yml` |
 
 Other `agent:*` labels may be reserved for future expansion, but only `agent:codex` is currently supported by the templates.
 


### PR DESCRIPTION
Codex 0.101.0 authenticated via the ChatGPT subscription but failed the first turn with:
  "The 'gpt-5.2-codex' model is not supported when using Codex with a ChatGPT
   account."
The runner never passed --model, so Codex used its built-in default (gpt-5.2-codex), which ChatGPT-account auth doesn't allow → empty output, exit 1, no work done.

Fix: pass --model "$CODEX_MODEL" to `codex exec`, default gpt-5.1-codex, overridable per consumer via the CODEX_MODEL repo variable. Only added when the caller hasn't already supplied --model via codex_args.

Also updated docs that referenced gpt-5.2-codex, and added Issue 18 to the retrospective (CLI version vs model are independent; ChatGPT and API auth support different model sets).

https://claude.ai/code/session_01FC8XoyssN5v6hQCTtcjoB5