### PR TITLE
Fix verify:create-issue silently creating no follow-up issue

### DIFF
--- a/.github/workflows/agents-verify-to-issue-v2.yml
+++ b/.github/workflows/agents-verify-to-issue-v2.yml
@@ -133,9 +133,11 @@ jobs:
 
             // Find verification comment(s) - both evaluate and compare
             const verifyComments = comments.filter(c =>
+              c.body.includes('## Provider Comparison Report') ||
               c.body.includes('## PR Verification Report') ||
               c.body.includes('## PR Verification Comparison') ||
               c.body.includes('### Concerns') ||
+              c.body.includes('### Unique Insights') ||
               c.body.includes('Verdict:') ||
               c.body.includes('### ⚠️ Issues Detected')
             );
@@ -233,7 +235,15 @@ jobs:
 
       - name: Fallback to simple extraction
         id: fallback
-        if: steps.generate.outcome == 'failure' && steps.check-merged.outputs.merged == 'true'
+        # Fire not only on a hard failure but also when generation "succeeds"
+        # yet yields an empty title/body (e.g. the no-LLM path produced
+        # nothing usable). Without this the create step dies on empty output
+        # and no follow-up issue is created.
+        if: >-
+          steps.check-merged.outputs.merged == 'true' &&
+          (steps.generate.outcome == 'failure' ||
+           steps.generate.outputs.issue_title == '' ||
+           steps.generate.outputs.issue_body == '')
         uses: actions/github-script@v8
         with:
           github-token: ${{ steps.select-token.outputs.token }}

--- a/templates/consumer-repo/.github/workflows/agents-verify-to-issue-v2.yml
+++ b/templates/consumer-repo/.github/workflows/agents-verify-to-issue-v2.yml
@@ -129,9 +129,11 @@ jobs:
 
             // Find verification comment(s) - both evaluate and compare
             const verifyComments = comments.filter(c =>
+              c.body.includes('## Provider Comparison Report') ||
               c.body.includes('## PR Verification Report') ||
               c.body.includes('## PR Verification Comparison') ||
               c.body.includes('### Concerns') ||
+              c.body.includes('### Unique Insights') ||
               c.body.includes('Verdict:') ||
               c.body.includes('### ⚠️ Issues Detected')
             );
@@ -229,7 +231,15 @@ jobs:
 
       - name: Fallback to simple extraction
         id: fallback
-        if: steps.generate.outcome == 'failure' && steps.check-merged.outputs.merged == 'true'
+        # Fire not only on a hard failure but also when generation "succeeds"
+        # yet yields an empty title/body (e.g. the no-LLM path produced
+        # nothing usable). Without this the create step dies on empty output
+        # and no follow-up issue is created.
+        if: >-
+          steps.check-merged.outputs.merged == 'true' &&
+          (steps.generate.outcome == 'failure' ||
+           steps.generate.outputs.issue_title == '' ||
+           steps.generate.outputs.issue_body == '')
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           github-token: ${{ steps.select-token.outputs.token }}


### PR DESCRIPTION
On a merged PR the workflow fired but produced no issue: generation can exit 0 yet yield an empty title/body (e.g. the no-LLM path), and the fallback only ran on a hard failure — so it was skipped and the create step died on `if (!title || !body)`.

- Fallback now also fires when generate's title/body output is empty, not just on failure, so an issue is always produced.
- Comment finder now matches the actual verify:compare header "## Provider Comparison Report" (and "### Unique Insights"), which the old patterns missed.

Applied to source and consumer template.


Claude-Session: https://claude.ai/code/session_01FC8XoyssN5v6hQCTtcjoB5