### PR TITLE
Fix verify:create-issue crash (missing PYTHONPATH + dead fallback)

### DIFF
--- a/.github/workflows/agents-verify-to-issue-v2.yml
+++ b/.github/workflows/agents-verify-to-issue-v2.yml
@@ -206,6 +206,10 @@ jobs:
         id: generate
         if: steps.check-merged.outputs.merged == 'true'
         env:
+          # Repo root on PYTHONPATH so `from scripts.langchain import ...`
+          # resolves (running the script directly only puts scripts/langchain
+          # on the path, which breaks the import).
+          PYTHONPATH: ${{ github.workspace }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           CLAUDE_API_KEY: ${{ secrets.CLAUDE_API_KEY }}
           GITHUB_TOKEN: ${{ steps.select-token.outputs.token }}
@@ -236,10 +240,12 @@ jobs:
       - name: Fallback to simple extraction
         id: fallback
         # Fire not only on a hard failure but also when generation "succeeds"
-        # yet yields an empty title/body (e.g. the no-LLM path produced
-        # nothing usable). Without this the create step dies on empty output
-        # and no follow-up issue is created.
+        # yet yields an empty title/body. The leading !cancelled() supplies a
+        # status-check function so this step still evaluates after `generate`
+        # fails — without it the implicit success() gate would skip the
+        # fallback (and no follow-up issue would be created).
         if: >-
+          !cancelled() &&
           steps.check-merged.outputs.merged == 'true' &&
           (steps.generate.outcome == 'failure' ||
            steps.generate.outputs.issue_title == '' ||
@@ -326,7 +332,11 @@ jobs:
 
       - name: Create follow-up issue
         id: create-issue
-        if: steps.check-merged.outputs.merged == 'true'
+        # !cancelled() so this runs even when `generate` failed and the
+        # fallback produced the title/body.
+        if: >-
+          !cancelled() &&
+          steps.check-merged.outputs.merged == 'true'
         uses: actions/github-script@v8
         env:
           ISSUE_TITLE: >-

--- a/templates/consumer-repo/.github/workflows/agents-verify-to-issue-v2.yml
+++ b/templates/consumer-repo/.github/workflows/agents-verify-to-issue-v2.yml
@@ -202,6 +202,10 @@ jobs:
         id: generate
         if: steps.check-merged.outputs.merged == 'true'
         env:
+          # Repo root on PYTHONPATH so `from scripts.langchain import ...`
+          # resolves (running the script directly only puts scripts/langchain
+          # on the path, which breaks the import).
+          PYTHONPATH: ${{ github.workspace }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           CLAUDE_API_KEY: ${{ secrets.CLAUDE_API_KEY }}
           GITHUB_TOKEN: ${{ steps.select-token.outputs.token }}
@@ -232,10 +236,12 @@ jobs:
       - name: Fallback to simple extraction
         id: fallback
         # Fire not only on a hard failure but also when generation "succeeds"
-        # yet yields an empty title/body (e.g. the no-LLM path produced
-        # nothing usable). Without this the create step dies on empty output
-        # and no follow-up issue is created.
+        # yet yields an empty title/body. The leading !cancelled() supplies a
+        # status-check function so this step still evaluates after `generate`
+        # fails — without it the implicit success() gate would skip the
+        # fallback (and no follow-up issue would be created).
         if: >-
+          !cancelled() &&
           steps.check-merged.outputs.merged == 'true' &&
           (steps.generate.outcome == 'failure' ||
            steps.generate.outputs.issue_title == '' ||
@@ -322,7 +328,11 @@ jobs:
 
       - name: Create follow-up issue
         id: create-issue
-        if: steps.check-merged.outputs.merged == 'true'
+        # !cancelled() so this runs even when `generate` failed and the
+        # fallback produced the title/body.
+        if: >-
+          !cancelled() &&
+          steps.check-merged.outputs.merged == 'true'
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           ISSUE_TITLE: >-


### PR DESCRIPTION
The run failed with `ModuleNotFoundError: No module named 'scripts'`: followup_issue_generator.py does `from scripts.langchain import ...`, which needs the repo root on PYTHONPATH. Running the script directly only puts scripts/langchain on sys.path, so the import always crashed. The sibling verify-to-new-pr sets PYTHONPATH and works; v2 didn't.

- Add PYTHONPATH: ${{ github.workspace }} to the generate step.
- Add !cancelled() to the fallback and create-issue `if` conditions. Without a status-check function GitHub applies an implicit success() gate, so both steps were skipped once `generate` failed — making the fallback dead code and guaranteeing no issue on any generation error.

Applied to source and consumer template.


Claude-Session: https://claude.ai/code/session_01FC8XoyssN5v6hQCTtcjoB5