### PR TITLE
Add per-agent base_branch routing to the issue bridge

### DIFF
--- a/.github/agents/registry.yml
+++ b/.github/agents/registry.yml
@@ -5,6 +5,17 @@ default_agent: codex
 # Shared keepalive marker prefix (agent-agnostic)
 keepalive_marker_prefix: agent-keepalive
 
+# Optional per-agent field: base_branch
+#   The branch an agent's work branches from and its PRs target. When unset
+#   (the default), the bridge uses the repository default branch. Set it to a
+#   long-lived per-agent integration branch to stack an agent's work there
+#   instead of the default branch — e.g. for a Codex-vs-Claude evaluation:
+#       codex:  { base_branch: eval/codex }
+#       claude: { base_branch: eval/claude }
+#   The branch MUST already exist on origin. See
+#   docs/evaluations/AGENT_EVAL_RUNBOOK.md and
+#   docs/ops/CONSUMER_REPO_MAINTENANCE.md before enabling it.
+
 agents:
   codex:
     runner_workflow: .github/workflows/reusable-codex-run.yml
@@ -14,6 +25,7 @@ agents:
     required_secrets:
       - CODEX_AUTH_JSON
     branch_prefix: codex/issue-
+    # base_branch: eval/codex   # optional; see note above. Unset -> repo default branch.
     ui_mentions_allowed: false
     automation_logins:
       - chatgpt-codex-connector
@@ -38,6 +50,7 @@ agents:
       - CLAUDE_AUTH_JSON          # fallback: credentials.json (short-lived OAuth)
     required_secrets_mode: any    # at least one must be present
     branch_prefix: claude/issue-
+    # base_branch: eval/claude   # optional; see note above. Unset -> repo default branch.
     ui_mentions_allowed: false
     automation_logins:
       - kayleb-automation-bot

--- a/.github/sync-manifest.yml
+++ b/.github/sync-manifest.yml
@@ -281,6 +281,7 @@ scripts:
 
   - source: .github/agents/registry.yml
     description: "Agent registry - source of truth for agent keys and runner workflow mapping"
+    sync_mode: create_only  # Consumer-owned routing: base_branch (e.g. eval branches), enabled agents, and bot logins differ per repo. Seed once; do not clobber. See docs/ops/CONSUMER_REPO_MAINTENANCE.md.
 
   - source: .github/scripts/agent_registry.js
     description: "Agent registry helper - loads registry and resolves agent key from labels"

--- a/.github/workflows/reusable-agents-issue-bridge.yml
+++ b/.github/workflows/reusable-agents-issue-bridge.yml
@@ -301,28 +301,41 @@ jobs:
                 repo,
               }),
             );
-            const base = data.default_branch;
-            if (!base) {
+            const defaultBranch = data.default_branch;
+            if (!defaultBranch) {
               core.setFailed('Repository default branch not available');
               return;
             }
             const issue = Number('${{ steps.ctx.outputs.issue }}');
 
             let branchPrefix = 'codex/issue-';
+            // Base branch the agent's work branches from and the PR targets.
+            // Defaults to the repository default branch. An agent may override
+            // it via `base_branch` in the registry (e.g. a long-lived per-agent
+            // integration branch such as eval/claude or eval/codex) so its work
+            // stacks on that branch instead of the default branch. The branch
+            // must already exist on origin (see "Checkout target base").
+            let base = defaultBranch;
             if (agentKey) {
               try {
                 const { getAgentConfig } = require('./.github/scripts/agent_registry.js');
                 const cfg = getAgentConfig(agentKey);
                 branchPrefix = String(cfg.branch_prefix || branchPrefix);
+                const configuredBase = String(cfg.base_branch || '').trim();
+                if (configuredBase) {
+                  base = configuredBase;
+                }
               } catch (error) {
                 core.warning(
-                  `Could not load agent registry; defaulting branch prefix: ${error.message}`,
+                  `Could not load agent registry; defaulting branch prefix/base: ${error.message}`,
                 );
               }
             }
 
+            core.info(`Resolved base branch: ${base} (repo default: ${defaultBranch})`);
             const head = issue ? `${branchPrefix}${issue}` : '';
             core.setOutput('base', base);
+            core.setOutput('default_base', defaultBranch);
             if (head) {
               core.setOutput('head', head);
             }
@@ -342,11 +355,18 @@ jobs:
       - name: Checkout target base
         run: |
           TARGET_BASE="${{ steps.refs.outputs.base }}"
+          DEFAULT_BASE="${{ steps.refs.outputs.default_base }}"
           CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
           if [ "$TARGET_BASE" != "$CURRENT_BRANCH" ]; then
             git fetch origin "$TARGET_BASE" --depth=0 || true
-            if ! git checkout "$TARGET_BASE"; then
-              git checkout -b "$TARGET_BASE" "origin/$TARGET_BASE"
+            if ! git checkout "$TARGET_BASE" 2>/dev/null; then
+              if git ls-remote --exit-code --heads origin "$TARGET_BASE" >/dev/null 2>&1; then
+                git checkout -b "$TARGET_BASE" "origin/$TARGET_BASE"
+              else
+                echo "::error::Configured base branch '$TARGET_BASE' does not exist on origin."
+                echo "::error::Create it first (e.g. 'git branch $TARGET_BASE $DEFAULT_BASE && git push -u origin $TARGET_BASE'), or remove 'base_branch' from the agent registry to fall back to the default branch."
+                exit 1
+              fi
             fi
           fi
           echo "Scripts available:"

--- a/docs/evaluations/AGENT_EVAL_RUNBOOK.md
+++ b/docs/evaluations/AGENT_EVAL_RUNBOOK.md
@@ -18,6 +18,45 @@ consumer repo, and how to record the result. Written after the issues in
 4. **Trust cross-verdicts, not self-verdicts.** A model judging its own family's
    work is biased — weight the neutral judge (OpenAI `gpt-5.5`) most.
 
+## Automatic per-agent base branch (registry `base_branch`)
+
+The issue bridge routes each agent's initial issue→PR to the repository default
+branch **unless** the agent declares a `base_branch` in
+`.github/agents/registry.yml`:
+
+```yaml
+agents:
+  codex:  { base_branch: eval/codex }
+  claude: { base_branch: eval/claude }
+```
+
+With this set, an `agent:codex` issue produces `codex/issue-N` branched from
+`eval/codex` with its PR targeting `eval/codex` (same for Claude). This makes the
+`codex/issue-A → eval/codex` flow below automatic instead of manual. The eval
+branch **must already exist on origin** or the bridge fails fast with an
+actionable error. The registry is `create_only`, so this survives consumer syncs
+(see `../ops/CONSUMER_REPO_MAINTENANCE.md`).
+
+### Two evaluation modes — pick deliberately
+
+- **Independent-task comparison (this runbook's default).** Reset the eval
+  branches to `main` between comparisons (step 1). Each task is a clean, fair,
+  isolated test. This is what Principle #2 protects.
+- **Cumulative project build.** Issues are dependency-ordered and each is meant
+  to build on the previous (e.g. scaffold → auth → dashboard). Here accumulation
+  on `eval/<agent>` is the goal, not a bug — do **not** reset between issues.
+
+⚠️ **The Principle #2 hazard still applies to cumulative builds.** The PR #61
+merge failure came from *competing scaffolds* landing on a shared eval branch.
+To avoid it in cumulative mode, obey one rule:
+
+> **Run issues sequentially in dependency order. Merge issue N's PR into
+> `eval/<agent>` before filing issue N+1.** Then N+1 branches from an eval branch
+> that already contains N's work — no competing scaffolds, no merge collision.
+
+Parallelize only issues that touch disjoint files; anything that might overlap
+should run sequentially (or from `main` as an independent comparison).
+
 ## Preflight (one-time / when infra changed)
 
 Confirm the agent runtime is healthy before spending an evaluation on it. A

--- a/docs/ops/CONSUMER_REPO_MAINTENANCE.md
+++ b/docs/ops/CONSUMER_REPO_MAINTENANCE.md
@@ -166,6 +166,36 @@ Maint 68 is manifest-driven:
 
 Custom Gate repos are a special-case skip: their `pr-00-gate.yml` stays local.
 
+### Agent Registry Is Consumer-Owned (`create_only`)
+
+`.github/agents/registry.yml` is synced with `sync_mode: create_only`: the sync
+seeds it into a new consumer once, then never overwrites it. This is deliberate —
+the registry holds repo-specific routing that legitimately differs per consumer:
+which agents are enabled, their bot logins / required secrets, and the optional
+per-agent `base_branch`.
+
+**`base_branch`** (optional, per agent): the branch an agent's work branches from
+and its PRs target. Unset → the repository default branch (previous behavior).
+Set it to a long-lived per-agent integration branch to stack that agent's work
+there instead of the default branch — e.g. an evaluation build:
+
+```yaml
+agents:
+  codex:  { base_branch: eval/codex }
+  claude: { base_branch: eval/claude }
+```
+
+The branch **must already exist on origin** (`git branch eval/codex main && git push -u origin eval/codex`);
+the issue bridge fails fast with an actionable error if it does not. Because the
+registry is `create_only`, a `base_branch` set in a consumer survives future syncs.
+
+**Tradeoff to remember:** since the registry is no longer overwritten, changes to
+the *source* registry (new agents, renamed `runner_workflow` paths) do **not**
+auto-propagate to existing consumers. When the registry schema or agent set
+changes in Workflows, align consumer registries manually (or re-seed after
+removing the local copy). See `docs/evaluations/AGENT_EVAL_RUNBOOK.md` for the
+evaluation workflow that uses `base_branch`.
+
 ### Reusable Workflow Versioning
 
 First-party consumer repos currently call reusable workflows via `@main`.

--- a/templates/consumer-repo/.github/agents/registry.yml
+++ b/templates/consumer-repo/.github/agents/registry.yml
@@ -5,6 +5,17 @@ default_agent: codex
 # Shared keepalive marker prefix (agent-agnostic)
 keepalive_marker_prefix: agent-keepalive
 
+# Optional per-agent field: base_branch
+#   The branch an agent's work branches from and its PRs target. When unset
+#   (the default), the bridge uses the repository default branch. Set it to a
+#   long-lived per-agent integration branch to stack an agent's work there
+#   instead of the default branch — e.g. for a Codex-vs-Claude evaluation:
+#       codex:  { base_branch: eval/codex }
+#       claude: { base_branch: eval/claude }
+#   The branch MUST already exist on origin. This registry is create-only
+#   (see .github/sync-manifest.yml): sync will NOT overwrite it, so a base_branch
+#   set here survives future syncs. See docs/ops/CONSUMER_REPO_MAINTENANCE.md.
+
 agents:
   codex:
     runner_workflow: .github/workflows/reusable-codex-run.yml
@@ -14,6 +25,7 @@ agents:
     required_secrets:
       - CODEX_AUTH_JSON
     branch_prefix: codex/issue-
+    # base_branch: eval/codex   # optional; see note above. Unset -> repo default branch.
     ui_mentions_allowed: false
     automation_logins:
       - chatgpt-codex-connector
@@ -38,6 +50,7 @@ agents:
       - CLAUDE_AUTH_JSON          # fallback: credentials.json (short-lived OAuth)
     required_secrets_mode: any    # at least one must be present
     branch_prefix: claude/issue-
+    # base_branch: eval/claude   # optional; see note above. Unset -> repo default branch.
     ui_mentions_allowed: false
     automation_logins:
       - kayleb-automation-bot

--- a/tests/workflows/test_workflow_agents_consolidation.py
+++ b/tests/workflows/test_workflow_agents_consolidation.py
@@ -198,6 +198,44 @@ def test_issue_bridge_keepalive_dispatch_disabled():
     ), "Issue bridge should document that keepalive dispatch is disabled"
 
 
+def test_issue_bridge_honors_registry_base_branch():
+    text = (WORKFLOWS_DIR / "reusable-agents-issue-bridge.yml").read_text(encoding="utf-8")
+    # Base is resolved from the registry's optional base_branch, falling back to
+    # the repository default branch when unset.
+    assert "cfg.base_branch" in text, "Issue bridge must read base_branch from the agent registry"
+    assert (
+        "let base = defaultBranch;" in text
+    ), "Issue bridge must default the base to the repository default branch"
+    assert (
+        "core.setOutput('default_base', defaultBranch);" in text
+    ), "Issue bridge must expose the repository default branch as an output"
+    # A configured base branch that is missing on origin must fail with guidance,
+    # not a bare git error.
+    assert (
+        "does not exist on origin" in text
+    ), "Issue bridge must fail fast when a configured base branch is absent on origin"
+
+
+def test_agent_registry_documents_base_branch():
+    text = Path(".github/agents/registry.yml").read_text(encoding="utf-8")
+    assert "base_branch" in text, "Registry should document the optional base_branch field"
+
+
+def test_agent_registry_is_create_only_in_sync_manifest():
+    manifest = yaml.safe_load(Path(".github/sync-manifest.yml").read_text(encoding="utf-8"))
+    entries = [
+        entry
+        for section in manifest.values()
+        if isinstance(section, list)
+        for entry in section
+        if isinstance(entry, dict) and entry.get("source") == ".github/agents/registry.yml"
+    ]
+    assert entries, "Sync manifest must declare the agent registry"
+    assert all(
+        entry.get("sync_mode") == "create_only" for entry in entries
+    ), "Agent registry must be create_only so consumer-owned base_branch survives syncs"
+
+
 def test_keepalive_job_present():
     reusable = WORKFLOWS_DIR / "reusable-16-agents.yml"
     text = reusable.read_text(encoding="utf-8")


### PR DESCRIPTION
The issue bridge previously based every agent's initial issue->PR on the repository default branch. Agents can now declare an optional `base_branch` in the registry so their work branches from, and PRs target, a long-lived per-agent integration branch (e.g. eval/claude, eval/codex) for cumulative or evaluation builds. Unset preserves the existing default-branch behavior.

- reusable-agents-issue-bridge.yml: resolve base from cfg.base_branch with default-branch fallback; expose default_base output; fail fast with an actionable message when a configured base branch is missing on origin.
- registry.yml + consumer template: document the optional base_branch field (commented, so no behavior change).
- sync-manifest.yml: mark the agent registry create_only so a consumer-owned base_branch survives syncs.
- docs: document the field, the create_only tradeoff, and the sequential-merge rule that keeps cumulative eval builds clear of the Principle #2 hazard.
- tests: lock the bridge base_branch contract and the create_only manifest mode.


Claude-Session: https://claude.ai/code/session_01D1hjKKY54XzL5du1eo66aZ