### PR TITLE
Support non-default base branches for agent PRs (evaluation lanes)

### DIFF
--- a/.github/workflows/agents-verify-to-new-pr.yml
+++ b/.github/workflows/agents-verify-to-new-pr.yml
@@ -211,6 +211,23 @@ jobs:
 
             fs.writeFileSync('original_issue.txt', originalIssueBody);
 
+            // --- Base-branch propagation ---
+            // Carry the merged PR's base forward when it is NOT the default
+            // branch (evaluation lanes such as eval/claude). Without this the
+            // follow-up PR targets the default branch and the fix escapes the
+            // lane it belongs to. The bridge reads this marker back.
+            const prBaseRef = context.payload.pull_request.base?.ref || '';
+            const repoDefaultBranch =
+              context.payload.repository?.default_branch || '';
+            const nonDefaultBase =
+              prBaseRef && prBaseRef !== repoDefaultBranch ? prBaseRef : '';
+            if (nonDefaultBase) {
+              core.info(
+                `PR base '${nonDefaultBase}' is non-default; follow-up will target it.`,
+              );
+            }
+            core.setOutput('pr_base_ref', nonDefaultBase);
+
             // --- Chain depth tracking (P0) ---
             // Extract follow-up-depth from original issue body or PR body
             // Format: <!-- follow-up-depth: N -->
@@ -572,6 +589,7 @@ jobs:
           ORIGINAL_ISSUE_TITLE: ${{ steps.collect.outputs.original_issue_title }}
           PR_NUMBER: ${{ steps.check-merged.outputs.pr_number }}
           FOLLOW_UP_DEPTH: ${{ steps.chain-check.outputs.next_depth }}
+          PR_BASE_REF: ${{ steps.collect.outputs.pr_base_ref }}
         run: |
           # Generate using Python script
           python scripts/langchain/followup_issue_generator.py \
@@ -586,6 +604,11 @@ jobs:
           # Inject chain depth marker into generated body
           depth="${FOLLOW_UP_DEPTH:-1}"
           marker="<!-- follow-up-depth: ${depth} -->"
+          # Preserve a non-default base (evaluation lanes) so the follow-up PR
+          # targets the same branch the originating PR merged into.
+          if [ -n "${PR_BASE_REF:-}" ]; then
+            marker="$(printf '%s\n%s' "$marker" "<!-- base-branch: ${PR_BASE_REF} -->")"
+          fi
           jq --arg marker "$marker" \
             '.body = $marker + "\n" + .body' \
             followup_issue.json > followup_issue_tmp.json
@@ -613,11 +636,13 @@ jobs:
         env:
           FOLLOW_UP_DEPTH: ${{ steps.chain-check.outputs.next_depth }}
           EXTRACTED_VERDICT: ${{ steps.extract-verdict.outputs.verdict }}
+          PR_BASE_REF: ${{ steps.collect.outputs.pr_base_ref }}
         with:
           github-token: ${{ steps.select-token.outputs.token }}
           script: |
             // Fallback to structured extraction if Python script fails
             const fs = require('fs');
+            const prBaseRef = process.env.PR_BASE_REF || '';
             const prNumber = context.payload.pull_request.number;
             const prUrl = context.payload.pull_request.html_url;
             const depth = process.env.FOLLOW_UP_DEPTH || '1';
@@ -738,6 +763,7 @@ jobs:
 
             const issueBody = [
               `<!-- follow-up-depth: ${depth} -->`,
+              ...(prBaseRef ? [`<!-- base-branch: ${prBaseRef} -->`] : []),
               '## Why',
               '',
               `PR #${prNumber} was verified with verdict **${verdict}**. ` +

--- a/.github/workflows/reusable-agents-issue-bridge.yml
+++ b/.github/workflows/reusable-agents-issue-bridge.yml
@@ -50,6 +50,14 @@ on:
         required: false
         type: string
         default: "false"
+      base_branch:
+        description: >-
+          Optional base branch for the automation PR. Overrides the
+          `<!-- base-branch: X -->` issue marker and the repository default.
+          Used for evaluation lanes that must not target the default branch.
+        required: false
+        type: string
+        default: ""
     secrets:
       service_bot_pat:
         description: "PAT for service bot operations"
@@ -279,6 +287,10 @@ jobs:
       - name: Resolve base and head refs
         id: refs
         uses: actions/github-script@v9
+        env:
+          # Passed via env (not inline interpolation) so a caller-supplied
+          # value can never be injected into the script body.
+          INPUT_BASE_BRANCH: ${{ inputs.base_branch }}
         with:
           script: |
             const { owner, repo } = context.repo;
@@ -300,12 +312,63 @@ jobs:
                 repo,
               }),
             );
-            const base = data.default_branch;
-            if (!base) {
+            const defaultBranch = data.default_branch;
+            if (!defaultBranch) {
               core.setFailed('Repository default branch not available');
               return;
             }
             const issue = Number('${{ steps.ctx.outputs.issue }}');
+
+            // Base-branch resolution, highest priority first:
+            //   1. explicit `base_branch` input (caller override)
+            //   2. `<!-- base-branch: X -->` marker in the issue body
+            //   3. repository default branch
+            // Evaluation lanes rely on (1)/(2) so agent PRs land on
+            // eval/<agent> instead of the default branch.
+            let base = String(process.env.INPUT_BASE_BRANCH || '').trim();
+            let baseSource = base ? 'input' : '';
+
+            if (!base && issue) {
+              try {
+                const { data: issueData } = await withRetry(() =>
+                  api.rest.issues.get({ owner, repo, issue_number: issue }),
+                );
+                const marker = String(issueData.body || '').match(
+                  /<!--\s*base-branch:\s*([^\s>]+)\s*-->/,
+                );
+                if (marker) {
+                  base = marker[1].trim();
+                  baseSource = 'issue-marker';
+                }
+              } catch (error) {
+                core.warning(
+                  `Could not read issue #${issue} for a base-branch marker: ${error.message}`,
+                );
+              }
+            }
+
+            if (!base) {
+              base = defaultBranch;
+              baseSource = 'default';
+            }
+
+            // Never target a branch that does not exist: a stale or mistyped
+            // marker would otherwise wedge every dispatch for that issue.
+            if (base !== defaultBranch) {
+              try {
+                await withRetry(() =>
+                  api.rest.repos.getBranch({ owner, repo, branch: base }),
+                );
+              } catch (error) {
+                core.warning(
+                  `Base branch '${base}' (from ${baseSource}) not found; ` +
+                    `falling back to '${defaultBranch}'.`,
+                );
+                base = defaultBranch;
+                baseSource = 'default-fallback';
+              }
+            }
+            core.info(`Resolved PR base: ${base} (source: ${baseSource})`);
 
             let branchPrefix = 'codex/issue-';
             if (agentKey) {


### PR DESCRIPTION
Agent bootstrap PRs always targeted the repository default branch: the issue bridge hardcoded `base = data.default_branch` with no override. That makes per-agent evaluation lanes (eval/claude, eval/codex) impossible — every agent PR lands on main.

- reusable-agents-issue-bridge: resolve the PR base as base_branch input > `<!-- base-branch: X -->` issue marker > repo default, with an existence guard that falls back to the default when a marker names a missing branch (a typo can no longer wedge dispatch). The input is passed via env, not inline interpolation.
- agents-verify-to-new-pr: carry a non-default PR base into the generated follow-up issue as a base-branch marker (both the LLM and fallback paths), so remediation PRs stay in the lane instead of escaping to main.

Resolution order verified against all four cases; workflow YAML validator passes. Two pre-existing long-line lint failures in the bridge are upstream and untouched.

## Workflow Source

Started from:
- [ ] GitHub issue: #
- [ ] Direct PR / remote GitHub work
- [ ] Local Codex/user request
- [ ] Automation run
- [ ] Review follow-up from PR #
- [ ] Sync / maintenance campaign
- [ ] Dependabot or dependency update
- [ ] Do not automate

Automation intent:
- [ ] Verifier should review this
- [ ] Keepalive may manage this PR
- [ ] Human-only unless checks fail

Notes:
<!-- If there is no linked issue, briefly describe the source. Automation also accepts workflow source labels such as workflow:source-direct-pr. -->

## Summary


## Testing
